### PR TITLE
feat(dynamodb): opt-in fail-stop caps for unbounded query pre-walk + paged/scan gather

### DIFF
--- a/wrapper/dynamodb/crud.go
+++ b/wrapper/dynamodb/crud.go
@@ -1421,7 +1421,7 @@ func (c *Crud) Query(keyExpression *QueryExpression, pagedDataPtrSlice interface
 		_ddb.TimeOutDuration(_timeout), indexName,
 		keyCondition, keyValues, nil); e != nil {
 		// query error
-		return nil, fmt.Errorf("Query From Data Store Failed: (QueryPaged) %s", e.Error())
+		return nil, fmt.Errorf("Query From Data Store Failed: (QueryPaged) %w", e)
 	} else {
 		// query success
 		return dataList, nil
@@ -1795,7 +1795,9 @@ func (c *Crud) QueryPaginationData(itemsPerPage int64, keyExpression *QueryExpre
 	// query pagination data against dynamodb table
 	if pData, e := _ddb.QueryPaginationDataWithRetry(_actionRetries, _ddb.TimeOutDuration(_timeout), indexNamePtr, itemsPerPage, keyCondition, nil, keyValues); e != nil {
 		// query error
-		return nil, fmt.Errorf("QueryPaginationData From Data Store Failed: (QueryPaged) %s", e.Error())
+		// %w (not %s) so errors.Is(err, ErrResultSetTooLarge) works: *DynamoDBError
+		// now Unwraps to the sentinel when the fail-stop cap was hit.
+		return nil, fmt.Errorf("QueryPaginationData From Data Store Failed: (QueryPaged) %w", e)
 	} else {
 		// query success
 		if len(pData) > 0 {

--- a/wrapper/dynamodb/dynamodb.go
+++ b/wrapper/dynamodb/dynamodb.go
@@ -82,7 +82,8 @@ import (
 // (see MaxBatchWriteItems below).
 //
 // Source: https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_TransactWriteItems.html
-//         https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_TransactGetItems.html
+//
+//	https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_TransactGetItems.html
 const MaxTransactItems = 100
 
 // MaxBatchWriteItems is the maximum number of items allowed in a single
@@ -141,6 +142,18 @@ func (e *DynamoDBError) Error() string {
 	return e.ErrorMessage
 }
 
+// Unwrap surfaces the typed ErrResultSetTooLarge sentinel when this error
+// represents the query result-set fail-stop, so callers (and %w-wrapping layers
+// like crud.Query) can detect it with errors.Is. *DynamoDBError otherwise carries
+// no wrapped cause, so Unwrap returns nil for every ordinary error — leaving
+// errors.Is/As behavior for non-fail-stop errors unchanged.
+func (e *DynamoDBError) Unwrap() error {
+	if e != nil && e.ResultSetTooLarge {
+		return ErrResultSetTooLarge
+	}
+	return nil
+}
+
 // =====================================================================================================================
 // Query result-set fail-stop (latent O(N)/OOM guardrail)
 // =====================================================================================================================
@@ -197,6 +210,37 @@ func shouldWarnAtCrossing(prevCount, newCount, warnThreshold int64) bool {
 func newResultSetTooLargeError(operation string, count, capLimit int64, tableName string) error {
 	return fmt.Errorf("DynamoDB %s fail-stop: result set reached cap (count=%d, cap=%d) for table %s: %w",
 		operation, count, capLimit, tableName, ErrResultSetTooLarge)
+}
+
+// failStopOnMorePages reports whether a read loop must fail-stop. It fires ONLY
+// when (a) the running count has reached the hard cap AND (b) there is MORE data
+// beyond the cap (morePagesRemain). A complete result set whose size lands exactly
+// on the cap is NOT failed — failing a fully-retrieved, legitimately-complete
+// query would be stricter than the runtime that produced it (and never bounds any
+// unbounded work, since the work is already done). cap<=0 means unlimited.
+func failStopOnMorePages(count, capLimit int64, morePagesRemain bool) bool {
+	return morePagesRemain && exceedsHardCap(count, capLimit)
+}
+
+// rewrapNonRetryable re-wraps a non-retryable *DynamoDBError with a prefixed
+// message while PRESERVING its typed status flags (ResultSetTooLarge,
+// TransactionConditionalCheckFailed). The *WithRetry entry points construct a
+// fresh error on the no-retry path; copying only ErrorMessage there silently
+// drops the flags that are the documented detection mechanism for callers. This
+// helper makes flag preservation the default so that re-wrap sites cannot
+// regress it.
+func rewrapNonRetryable(prefix string, e *DynamoDBError) *DynamoDBError {
+	if e == nil {
+		return &DynamoDBError{ErrorMessage: prefix + "<nil>"}
+	}
+	return &DynamoDBError{
+		ErrorMessage:                      prefix + e.ErrorMessage,
+		SuppressError:                     false,
+		AllowRetry:                        false,
+		RetryNeedsBackOff:                 false,
+		TransactionConditionalCheckFailed: e.TransactionConditionalCheckFailed,
+		ResultSetTooLarge:                 e.ResultSetTooLarge,
+	}
 }
 
 //// =====================================================================================================================
@@ -990,6 +1034,16 @@ type DynamoDB struct {
 	//   >0 = custom threshold
 	WarnQueryPaginationPageWalk int64
 	WarnQueryPagedItems         int64
+
+	// MaxScanPagedItems / WarnScanPagedItems guard ScanPagedItemsWithRetry, which
+	// accumulates EVERY matching item from a table SCAN into one in-memory slice —
+	// the same unbounded-gather hazard as QueryPagedItemsWithRetry but worse, since
+	// a Scan reads the whole table, not one partition. Kept separate from the Query
+	// caps so a Scan (rarely legitimate at scale) can be bounded far more tightly.
+	// Same convention: Max 0 = unlimited (default, preserves pre-cap contract);
+	// Warn 0 = built-in default (defaultWarnPagedItems), <0 = disabled, >0 = custom.
+	MaxScanPagedItems  int64
+	WarnScanPagedItems int64
 
 	_parentSegment      *xray.XRayParentSegment
 	_parentSegmentMutex sync.RWMutex
@@ -1971,7 +2025,12 @@ func (d *DynamoDB) do_Query_Pagination_Data(input *dynamodb.QueryInput, ctx ...a
 			if shouldWarnAtCrossing(pagesWalked-1, pagesWalked, warnPages) {
 				log.Printf("[WARN] DynamoDB do_Query_Pagination_Data pre-walk crossed %d pages for table %s — partition is growing; consider setting MaxQueryPaginationPageWalk", warnPages, d.TableName)
 			}
-			if exceedsHardCap(pagesWalked, d.MaxQueryPaginationPageWalk) {
+			// Fail-stop ONLY when more pages remain beyond the cap (!lastPage); a
+			// walk that reaches the cap exactly on its final page has retrieved a
+			// COMPLETE set and must not be rejected (never-truncate / not-stricter-
+			// than-runtime). This also means a zero-result or single-page query
+			// (lastPage on the first call) is never failed by any cap value.
+			if failStopOnMorePages(pagesWalked, d.MaxQueryPaginationPageWalk, !lastPage) {
 				capErr = newResultSetTooLargeError("do_Query_Pagination_Data", pagesWalked, d.MaxQueryPaginationPageWalk, d.TableName)
 				return false // stop the walk; capErr is returned below
 			}
@@ -4795,20 +4854,11 @@ func (d *DynamoDB) QueryPaginationDataWithRetry(
 				log.Println("QueryPaginationDataWithRetry Failed: " + ddbErr.ErrorMessage)
 				return d.QueryPaginationDataWithRetry(maxRetries-1, util.DurationPtr(timeout), indexName, itemsPerPage, keyConditionExpression, expressionAttributeNames, expressionAttributeValues)
 			} else {
-				return nil, &DynamoDBError{
-					ErrorMessage:      "QueryPaginationDataWithRetry Failed: " + ddbErr.ErrorMessage,
-					SuppressError:     false,
-					AllowRetry:        false,
-					RetryNeedsBackOff: false,
-				}
+				// preserve typed status flags (ResultSetTooLarge, etc.) across the re-wrap
+				return nil, rewrapNonRetryable("QueryPaginationDataWithRetry Failed: ", ddbErr)
 			}
 		} else {
-			return nil, &DynamoDBError{
-				ErrorMessage:      "QueryPaginationDataWithRetry Failed: (MaxRetries Exhausted) " + ddbErr.ErrorMessage,
-				SuppressError:     false,
-				AllowRetry:        false,
-				RetryNeedsBackOff: false,
-			}
+			return nil, rewrapNonRetryable("QueryPaginationDataWithRetry Failed: (MaxRetries Exhausted) ", ddbErr)
 		}
 	} else {
 		// no error
@@ -5932,12 +5982,19 @@ func (d *DynamoDB) QueryPagedItemsWithRetry(maxRetries uint,
 			if shouldWarnAtCrossing(prevLen, newLen, warnItems) {
 				log.Printf("[WARN] DynamoDB QueryPagedItemsWithRetry gather crossed %d items for table %s — partition is growing; consider setting MaxQueryPagedItems", warnItems, d.TableName)
 			}
-			if exceedsHardCap(newLen, d.MaxQueryPagedItems) {
-				// fail-stop: discard the accumulator, never truncate
+
+			morePages := len(prevEvalKey) != 0
+			// Fail-stop ONLY when more pages remain beyond the cap. A gather that
+			// reaches the cap exactly on the final page (no continuation key) has a
+			// COMPLETE set and must be returned, not rejected (never-truncate).
+			if failStopOnMorePages(newLen, d.MaxQueryPagedItems, morePages) {
+				// fail-stop: truly discard the accumulator (which is the caller's
+				// slice via reflect) so no partial/truncated data is left behind.
+				resultVal.Set(reflect.MakeSlice(resultVal.Type(), 0, 0))
 				return nil, newResultSetTooLargeError("QueryPagedItemsWithRetry", newLen, d.MaxQueryPagedItems, d.TableName)
 			}
 
-			if len(prevEvalKey) == 0 {
+			if !morePages {
 				break
 			}
 		}
@@ -6669,6 +6726,12 @@ func (d *DynamoDB) ScanPagedItemsWithRetry(maxRetries uint,
 		resultVal.Set(reflect.MakeSlice(resultVal.Type(), 0, 0))
 	}
 
+	// Fail-stop guardrail for the unbounded full-table scan gather (the twin of
+	// QueryPagedItemsWithRetry, but worse: a Scan reads the WHOLE table). Same
+	// contract: cap default 0 = unlimited; fail-stop with ErrResultSetTooLarge,
+	// never truncate. Uses the dedicated MaxScanPagedItems/WarnScanPagedItems.
+	warnItems := effectiveWarnThreshold(d.WarnScanPagedItems, defaultWarnPagedItems)
+
 	for {
 		// create fresh working slice each iteration to avoid pointer aliasing across pages
 		workingSliceType := valPaged.Elem().Type()
@@ -6682,9 +6745,21 @@ func (d *DynamoDB) ScanPagedItemsWithRetry(maxRetries uint,
 			return nil, fmt.Errorf("ScanPagedItemsWithRetry Failed: %s", e)
 		} else {
 			// success
+			prevLen := int64(resultVal.Len())
 			resultVal.Set(reflect.AppendSlice(resultVal, workingPtr.Elem()))
+			newLen := int64(resultVal.Len())
 
-			if len(prevEvalKey) == 0 {
+			if shouldWarnAtCrossing(prevLen, newLen, warnItems) {
+				log.Printf("[WARN] DynamoDB ScanPagedItemsWithRetry gather crossed %d items for table %s — full-table scan is large; consider setting MaxScanPagedItems", warnItems, d.TableName)
+			}
+
+			morePages := len(prevEvalKey) != 0
+			if failStopOnMorePages(newLen, d.MaxScanPagedItems, morePages) {
+				resultVal.Set(reflect.MakeSlice(resultVal.Type(), 0, 0)) // truly discard, never truncate
+				return nil, newResultSetTooLargeError("ScanPagedItemsWithRetry", newLen, d.MaxScanPagedItems, d.TableName)
+			}
+
+			if !morePages {
 				break
 			}
 		}

--- a/wrapper/dynamodb/dynamodb.go
+++ b/wrapper/dynamodb/dynamodb.go
@@ -123,6 +123,14 @@ type DynamoDBError struct {
 	RetryNeedsBackOff bool
 
 	TransactionConditionalCheckFailed bool
+
+	// ResultSetTooLarge is set true when the failure is the deterministic
+	// fail-stop raised by a query whose result set exceeded a configured cap
+	// (see ErrResultSetTooLarge, MaxQueryPaginationPageWalk, MaxQueryPagedItems).
+	// Because *DynamoDBError is a flat struct with no Unwrap, this flag is how
+	// callers of the *WithRetry entry points detect the cap was hit. It is never
+	// AllowRetry — retrying a deterministic fail-stop only re-incurs the walk.
+	ResultSetTooLarge bool
 }
 
 // Error returns error string of the struct object
@@ -131,6 +139,64 @@ func (e *DynamoDBError) Error() string {
 		return ""
 	}
 	return e.ErrorMessage
+}
+
+// =====================================================================================================================
+// Query result-set fail-stop (latent O(N)/OOM guardrail)
+// =====================================================================================================================
+
+// ErrResultSetTooLarge is the typed sentinel returned (wrapped) when a query
+// read loop is stopped because its result set exceeded a configured hard cap
+// (MaxQueryPaginationPageWalk / MaxQueryPagedItems). Plain-error callers detect
+// it with errors.Is; *DynamoDBError callers detect it via the
+// DynamoDBError.ResultSetTooLarge flag. The fail-stop NEVER truncates.
+var ErrResultSetTooLarge = errors.New("dynamodb query result set exceeded configured fail-stop cap")
+
+// Built-in soft-WARN thresholds. These are early-visibility signals only and
+// never fail a call, so a baked non-zero default is safe. They sit far above a
+// normal partition; crossing one means a partition has grown abnormally large
+// and an operator should consider an explicit hard cap.
+const (
+	defaultWarnPaginationPageWalk int64 = 1000   // ~1000 DynamoDB round-trips in one pre-walk
+	defaultWarnPagedItems         int64 = 100000 // ~100k items accumulated in one gather
+)
+
+// exceedsHardCap reports whether a running count has reached a hard cap. A cap
+// <= 0 means unlimited (the default), so this returns false — preserving the
+// pre-cap behavior for every caller that sets no cap. The boundary is >= (not
+// >) because reaching the cap means the bounded work has already been done.
+func exceedsHardCap(count, capLimit int64) bool {
+	return capLimit > 0 && count >= capLimit
+}
+
+// effectiveWarnThreshold resolves a WarnQuery* field into the threshold to use:
+// 0 -> the built-in default (warn on by default); <0 -> 0 (warn disabled);
+// >0 -> the field value (custom threshold).
+func effectiveWarnThreshold(field, builtinDefault int64) int64 {
+	switch {
+	case field < 0:
+		return 0
+	case field == 0:
+		return builtinDefault
+	default:
+		return field
+	}
+}
+
+// shouldWarnAtCrossing reports whether a running count crossed the warn
+// threshold on this step (prevCount below, newCount at-or-above). It fires
+// exactly once regardless of step size, so neither the per-page pre-walk
+// (step 1) nor the per-page gather (step up to a page of items) spams the log.
+// A threshold <= 0 is disabled and never fires.
+func shouldWarnAtCrossing(prevCount, newCount, warnThreshold int64) bool {
+	return warnThreshold > 0 && prevCount < warnThreshold && newCount >= warnThreshold
+}
+
+// newResultSetTooLargeError builds the fail-stop error wrapping ErrResultSetTooLarge
+// (so errors.Is works) and embedding operator-actionable context.
+func newResultSetTooLargeError(operation string, count, capLimit int64, tableName string) error {
+	return fmt.Errorf("DynamoDB %s fail-stop: result set reached cap (count=%d, cap=%d) for table %s: %w",
+		operation, count, capLimit, tableName, ErrResultSetTooLarge)
 }
 
 //// =====================================================================================================================
@@ -894,6 +960,37 @@ type DynamoDB struct {
 	// Default false preserves the v1.8.6 observable contract.
 	DisableLastExecuteParamsPayload bool
 
+	// Query fail-stop caps (latent O(N)/OOM guardrail).
+	//
+	// Two read paths in this wrapper are unbounded by default:
+	//   - the pre-walk in do_Query_Pagination_Data (drives QueryPaginationData*),
+	//     which walks EVERY page just to collect each page's ExclusiveStartKey;
+	//   - the full-result gather in QueryPagedItemsWithRetry (reached by
+	//     crud.Query when itemsPerPage<=0), which accumulates EVERY matching item.
+	// For a large partition either path can pin CPU (round-trips) or OOM a task.
+	//
+	// MaxQueryPaginationPageWalk caps the number of pages the pre-walk will read.
+	// MaxQueryPagedItems caps the number of items the full-result gather will
+	// accumulate. When the cap is reached the call FAILS-STOP with
+	// ErrResultSetTooLarge — it NEVER truncates (silent truncation of a payment
+	// transaction list is a data-integrity regression).
+	//
+	// Default 0 = unlimited, preserving the pre-cap observable contract for every
+	// existing caller (validation-not-stricter-than-runtime). Opt in per-table by
+	// setting a ceiling ABOVE that table's measured maximum partition size.
+	MaxQueryPaginationPageWalk int64
+	MaxQueryPagedItems         int64
+
+	// Soft-WARN thresholds for the same two paths. Unlike the hard caps these are
+	// purely observational: crossing the threshold logs a single [WARN] and never
+	// fails the call, so a non-zero default is safe (a log has no functional
+	// consequence). Convention:
+	//   0  = use the built-in default (defaultWarnPaginationPageWalk / defaultWarnPagedItems)
+	//   <0 = disabled (no warning)
+	//   >0 = custom threshold
+	WarnQueryPaginationPageWalk int64
+	WarnQueryPagedItems         int64
+
 	_parentSegment      *xray.XRayParentSegment
 	_parentSegmentMutex sync.RWMutex
 }
@@ -1114,6 +1211,9 @@ func (d *DynamoDB) handleError(err error, errorPrefix ...string) *DynamoDBError 
 			AllowRetry:                        false,
 			RetryNeedsBackOff:                 false,
 			TransactionConditionalCheckFailed: false,
+			// the deterministic result-set fail-stop is surfaced as a typed flag
+			// (no Unwrap on *DynamoDBError) and stays non-retryable.
+			ResultSetTooLarge: errors.Is(err, ErrResultSetTooLarge),
 		}
 	}
 }
@@ -1853,9 +1953,27 @@ func (d *DynamoDB) do_Query_Pagination_Data(input *dynamodb.QueryInput, ctx ...a
 
 		paginationData := make([]map[string]*dynamodb.AttributeValue, 0)
 
+		// Fail-stop guardrail for the unbounded pre-walk: bound the number of
+		// pages (DynamoDB round-trips) read. pagesWalked counts every page
+		// regardless of whether it carries a continuation key, so it bounds cost
+		// directly. capErr, when set, fails the call AFTER the walk stops — we
+		// never return the partially-collected pagination data (no truncation).
+		var pagesWalked int64
+		var capErr error
+		warnPages := effectiveWarnThreshold(d.WarnQueryPaginationPageWalk, defaultWarnPaginationPageWalk)
+
 		pageFn := func(pageOutput *dynamodb.QueryOutput, lastPage bool) bool {
 			if err := ctxToUse.Err(); err != nil {
 				return false // honor cancellation if context is done
+			}
+
+			pagesWalked++
+			if shouldWarnAtCrossing(pagesWalked-1, pagesWalked, warnPages) {
+				log.Printf("[WARN] DynamoDB do_Query_Pagination_Data pre-walk crossed %d pages for table %s — partition is growing; consider setting MaxQueryPaginationPageWalk", warnPages, d.TableName)
+			}
+			if exceedsHardCap(pagesWalked, d.MaxQueryPaginationPageWalk) {
+				capErr = newResultSetTooLargeError("do_Query_Pagination_Data", pagesWalked, d.MaxQueryPaginationPageWalk, d.TableName)
+				return false // stop the walk; capErr is returned below
 			}
 
 			if pageOutput == nil {
@@ -1880,6 +1998,9 @@ func (d *DynamoDB) do_Query_Pagination_Data(input *dynamodb.QueryInput, ctx ...a
 
 		if err != nil {
 			return nil, err
+		}
+		if capErr != nil {
+			return nil, capErr
 		}
 		return paginationData, nil
 	}
@@ -5777,6 +5898,11 @@ func (d *DynamoDB) QueryPagedItemsWithRetry(maxRetries uint,
 		resultVal.Set(reflect.MakeSlice(resultVal.Type(), 0, 0))
 	}
 
+	// Fail-stop guardrail for the unbounded full-result gather: bound the total
+	// number of items accumulated in memory. When the cap is reached we return
+	// ErrResultSetTooLarge and discard the accumulator — never a truncated slice.
+	warnItems := effectiveWarnThreshold(d.WarnQueryPagedItems, defaultWarnPagedItems)
+
 	for {
 		// We create a new `pagedSlicePtr` variable for each `for` loop iteration instead of reusing the same one
 		// because it is a pointer. When using `reflect.AppendSlice`, only a pointer struct is copied into the slice.
@@ -5799,7 +5925,17 @@ func (d *DynamoDB) QueryPagedItemsWithRetry(maxRetries uint,
 			return nil, fmt.Errorf("QueryPagedItemsWithRetry Failed: %s", e)
 		} else {
 			// append into accumulator
+			prevLen := int64(resultVal.Len())
 			resultVal.Set(reflect.AppendSlice(resultVal, newPagedSlicePtr.Elem()))
+			newLen := int64(resultVal.Len())
+
+			if shouldWarnAtCrossing(prevLen, newLen, warnItems) {
+				log.Printf("[WARN] DynamoDB QueryPagedItemsWithRetry gather crossed %d items for table %s — partition is growing; consider setting MaxQueryPagedItems", warnItems, d.TableName)
+			}
+			if exceedsHardCap(newLen, d.MaxQueryPagedItems) {
+				// fail-stop: discard the accumulator, never truncate
+				return nil, newResultSetTooLargeError("QueryPagedItemsWithRetry", newLen, d.MaxQueryPagedItems, d.TableName)
+			}
 
 			if len(prevEvalKey) == 0 {
 				break

--- a/wrapper/dynamodb/dynamodb.go
+++ b/wrapper/dynamodb/dynamodb.go
@@ -128,9 +128,11 @@ type DynamoDBError struct {
 	// ResultSetTooLarge is set true when the failure is the deterministic
 	// fail-stop raised by a query whose result set exceeded a configured cap
 	// (see ErrResultSetTooLarge, MaxQueryPaginationPageWalk, MaxQueryPagedItems).
-	// Because *DynamoDBError is a flat struct with no Unwrap, this flag is how
-	// callers of the *WithRetry entry points detect the cap was hit. It is never
-	// AllowRetry — retrying a deterministic fail-stop only re-incurs the walk.
+	// This flag is the primary detection path for callers of the *WithRetry entry
+	// points, which receive a *DynamoDBError directly. (Unwrap also surfaces
+	// ErrResultSetTooLarge when this flag is set, so errors.Is works through
+	// %w-wrapping layers like crud.Query.) It is never AllowRetry — retrying a
+	// deterministic fail-stop only re-incurs the walk.
 	ResultSetTooLarge bool
 }
 
@@ -1266,7 +1268,7 @@ func (d *DynamoDB) handleError(err error, errorPrefix ...string) *DynamoDBError 
 			RetryNeedsBackOff:                 false,
 			TransactionConditionalCheckFailed: false,
 			// the deterministic result-set fail-stop is surfaced as a typed flag
-			// (no Unwrap on *DynamoDBError) and stays non-retryable.
+			// (and via Unwrap when set) and stays non-retryable.
 			ResultSetTooLarge: errors.Is(err, ErrResultSetTooLarge),
 		}
 	}

--- a/wrapper/dynamodb/dynamodb_prewalk_failstop_test.go
+++ b/wrapper/dynamodb/dynamodb_prewalk_failstop_test.go
@@ -185,9 +185,10 @@ func TestNewResultSetTooLargeError_IsErrorsIsDetectable(t *testing.T) {
 // contract in this file. It pins TWO things at once:
 //
 //   - Detectability across the *DynamoDBError boundary: the WithRetry entry
-//     points return *DynamoDBError (which is a flat struct with no Unwrap), so a
-//     dedicated ResultSetTooLarge bool — mirroring TransactionConditionalCheckFailed
-//     — is how callers of QueryPaginationDataWithRetry detect the fail-stop.
+//     points return *DynamoDBError, so a dedicated ResultSetTooLarge bool —
+//     mirroring TransactionConditionalCheckFailed — is the primary way callers of
+//     QueryPaginationDataWithRetry detect the fail-stop (Unwrap additionally
+//     surfaces ErrResultSetTooLarge for errors.Is through %w layers).
 //   - No retry amplification: the fail-stop is deterministic, so it MUST NOT be
 //     retried. QueryPaginationDataWithRetry recurses only when AllowRetry is
 //     true; a retried walk would re-incur the full bounded walk N times. The

--- a/wrapper/dynamodb/dynamodb_prewalk_failstop_test.go
+++ b/wrapper/dynamodb/dynamodb_prewalk_failstop_test.go
@@ -1,0 +1,257 @@
+package dynamodb
+
+/*
+ * Copyright 2020-2026 Aldelo, LP
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// This file pins the fail-stop guardrails added for the two unbounded DynamoDB
+// read loops in this wrapper:
+//
+//  1. do_Query_Pagination_Data — the "pre-walk" that drives QueryPaginationData*.
+//     It walks EVERY page of a query result just to collect each page's
+//     ExclusiveStartKey for pre-building pagination buttons. That is
+//     O(total-matching-items / itemsPerPage) DynamoDB round-trips per list call.
+//  2. QueryPagedItemsWithRetry — the unbounded full-result gather reached by
+//     crud.Query() (taken when itemsPerPage<=0). It accumulates EVERY matching
+//     item into one in-memory slice.
+//
+// Both are latent O(N)/OOM bombs: harmless while partitions are tiny, fatal for
+// a large partition. The guardrail must FAIL-STOP with a typed sentinel
+// (ErrResultSetTooLarge) — it must NEVER truncate, because silent truncation of
+// a payment-transaction list is a data-integrity regression.
+//
+// Backward-compat is the hard constraint (validation-not-stricter-than-runtime):
+// the hard caps default to 0 = unlimited, so every existing DAL-service caller
+// behaves byte-identically to today. A soft [WARN] threshold (default on) gives
+// early visibility of a growing partition WITHOUT ever failing a legitimate
+// caller.
+//
+// Why not an integration test: the cap/warn DECISION logic is pure and is
+// exercised here directly, and the retry-classification contract is exercised
+// through handleError — neither needs an AWS connection. Driving the actual
+// QueryPages/Query loops would require live AWS, credentials and a large table,
+// which CI cannot provide deterministically.
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+// =============================================================================
+// Pure cap-decision helpers — the heart of the fail-stop
+// =============================================================================
+
+// TestExceedsHardCap_ZeroOrNegativeCapIsUnlimited pins the load-bearing
+// backward-compat contract: a cap <= 0 means "unlimited", so the helper returns
+// false no matter how large the running count is. The zero value of the new
+// MaxQuery* fields therefore preserves the pre-cap (today's) behavior exactly.
+func TestExceedsHardCap_ZeroOrNegativeCapIsUnlimited(t *testing.T) {
+	for _, capLimit := range []int64{0, -1, -1000} {
+		if exceedsHardCap(1<<62, capLimit) {
+			t.Errorf("exceedsHardCap(huge, %d) = true, want false — cap<=0 must mean unlimited (backward-compat)", capLimit)
+		}
+		if exceedsHardCap(0, capLimit) {
+			t.Errorf("exceedsHardCap(0, %d) = true, want false", capLimit)
+		}
+	}
+}
+
+// TestExceedsHardCap_Boundary pins the exact fail-stop boundary: the cap fires
+// at-or-above the limit, not just strictly above. Reaching the cap means the
+// loop has already gathered cap items/pages, which is precisely the work we
+// want bounded, so >= (not >) is correct.
+func TestExceedsHardCap_Boundary(t *testing.T) {
+	const capLimit = int64(100)
+	cases := []struct {
+		count int64
+		want  bool
+	}{
+		{99, false},
+		{100, true},
+		{101, true},
+	}
+	for _, c := range cases {
+		if got := exceedsHardCap(c.count, capLimit); got != c.want {
+			t.Errorf("exceedsHardCap(%d, %d) = %v, want %v", c.count, capLimit, got, c.want)
+		}
+	}
+}
+
+// TestEffectiveWarnThreshold pins the three-way warn-field convention:
+//
+//	field == 0  -> built-in default (warn is on by default)
+//	field <  0  -> 0 (warn explicitly disabled)
+//	field >  0  -> field (custom threshold)
+//
+// This is deliberately different from the hard-cap convention (0 = unlimited)
+// because a [WARN] has no functional consequence, so default-on is safe and
+// useful; disabling requires an explicit negative opt-out.
+func TestEffectiveWarnThreshold(t *testing.T) {
+	const builtin = int64(1000)
+	cases := []struct {
+		field int64
+		want  int64
+	}{
+		{0, builtin},   // unset -> default on
+		{-1, 0},        // negative -> disabled
+		{-9999, 0},     // any negative -> disabled
+		{1, 1},         // custom low
+		{50000, 50000}, // custom high
+	}
+	for _, c := range cases {
+		if got := effectiveWarnThreshold(c.field, builtin); got != c.want {
+			t.Errorf("effectiveWarnThreshold(%d, %d) = %d, want %d", c.field, builtin, got, c.want)
+		}
+	}
+}
+
+// TestShouldWarnAtCrossing_FiresExactlyOnce verifies the warn fires once, on the
+// transition from below-threshold to at-or-above-threshold. Both loops increment
+// their running count (the pre-walk by 1 per page; the gather by up to a page of
+// items), so a crossing predicate keyed on (prev, new) fires once for either
+// step size and never spams the log.
+func TestShouldWarnAtCrossing_FiresExactlyOnce(t *testing.T) {
+	const warn = int64(1000)
+
+	// pre-walk style: count increments by 1 each page
+	if shouldWarnAtCrossing(998, 999, warn) {
+		t.Error("below threshold must not warn")
+	}
+	if !shouldWarnAtCrossing(999, 1000, warn) {
+		t.Error("exact crossing (999->1000) must warn")
+	}
+	if shouldWarnAtCrossing(1000, 1001, warn) {
+		t.Error("already past threshold must not warn again (no spam)")
+	}
+
+	// gather style: count jumps by a full page, overshooting the threshold
+	if !shouldWarnAtCrossing(800, 1050, warn) {
+		t.Error("overshoot crossing (800->1050) must warn exactly once")
+	}
+	if shouldWarnAtCrossing(1050, 1300, warn) {
+		t.Error("subsequent gather steps past threshold must not warn again")
+	}
+}
+
+// TestShouldWarnAtCrossing_DisabledThresholdNeverWarns confirms a 0/negative
+// effective threshold disables the warn entirely.
+func TestShouldWarnAtCrossing_DisabledThresholdNeverWarns(t *testing.T) {
+	for _, warn := range []int64{0, -1} {
+		if shouldWarnAtCrossing(0, 1<<62, warn) {
+			t.Errorf("shouldWarnAtCrossing with warn=%d must never fire", warn)
+		}
+	}
+}
+
+// =============================================================================
+// Typed sentinel — detectability + non-retryability
+// =============================================================================
+
+// TestNewResultSetTooLargeError_IsErrorsIsDetectable verifies the constructed
+// error both wraps the package sentinel (so plain-error callers, e.g. the
+// QueryPagedItemsWithRetry path, can use errors.Is) AND carries actionable
+// context (operation, count, cap, table) in its message for operators.
+func TestNewResultSetTooLargeError_IsErrorsIsDetectable(t *testing.T) {
+	err := newResultSetTooLargeError("QueryPagedItemsWithRetry", 250, 100, "live-edc-tran-2026-06")
+	if err == nil {
+		t.Fatal("newResultSetTooLargeError returned nil")
+	}
+	if !errors.Is(err, ErrResultSetTooLarge) {
+		t.Errorf("errors.Is(err, ErrResultSetTooLarge) = false, want true — caller cannot detect the fail-stop")
+	}
+	msg := err.Error()
+	for _, want := range []string{"QueryPagedItemsWithRetry", "250", "100", "live-edc-tran-2026-06"} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("error message %q missing %q", msg, want)
+		}
+	}
+}
+
+// TestHandleError_ResultSetTooLarge_FlaggedAndNonRetryable is the most important
+// contract in this file. It pins TWO things at once:
+//
+//   - Detectability across the *DynamoDBError boundary: the WithRetry entry
+//     points return *DynamoDBError (which is a flat struct with no Unwrap), so a
+//     dedicated ResultSetTooLarge bool — mirroring TransactionConditionalCheckFailed
+//     — is how callers of QueryPaginationDataWithRetry detect the fail-stop.
+//   - No retry amplification: the fail-stop is deterministic, so it MUST NOT be
+//     retried. QueryPaginationDataWithRetry recurses only when AllowRetry is
+//     true; a retried walk would re-incur the full bounded walk N times. The
+//     sentinel is a non-AWS error, so handleError's general branch keeps
+//     AllowRetry=false — this test guards that the cap stays non-retryable.
+func TestHandleError_ResultSetTooLarge_FlaggedAndNonRetryable(t *testing.T) {
+	d := &DynamoDB{} // nil connection is fine — handleError doesn't use it
+
+	// the wrapped sentinel as it would arrive from do_Query_Pagination_Data
+	walkErr := newResultSetTooLargeError("do_Query_Pagination_Data", 1000, 1000, "live-edc-tran-2026-06")
+	ddbErr := d.handleError(walkErr, "QueryPaginationDataNormal Failed:")
+	if ddbErr == nil {
+		t.Fatal("handleError returned nil for the fail-stop sentinel")
+	}
+	if !ddbErr.ResultSetTooLarge {
+		t.Error("ResultSetTooLarge = false, want true — caller cannot detect the fail-stop on the *DynamoDBError path")
+	}
+	if ddbErr.AllowRetry {
+		t.Error("AllowRetry = true, want false — the deterministic fail-stop must NOT be retried (retry amplification)")
+	}
+}
+
+// TestHandleError_OrdinaryError_DoesNotSetResultSetTooLarge guards against the
+// flag leaking onto unrelated errors.
+func TestHandleError_OrdinaryError_DoesNotSetResultSetTooLarge(t *testing.T) {
+	d := &DynamoDB{}
+	ddbErr := d.handleError(errors.New("some other failure"))
+	if ddbErr == nil {
+		t.Fatal("handleError returned nil")
+	}
+	if ddbErr.ResultSetTooLarge {
+		t.Error("ResultSetTooLarge = true for an ordinary error, want false")
+	}
+}
+
+// =============================================================================
+// Backward-compat + contract pins
+// =============================================================================
+
+// TestDynamoDB_ZeroValue_HardCapsAreUnlimited pins that a freshly constructed
+// DynamoDB (as every DAL service constructs it today, setting none of the new
+// fields) has both hard caps at 0 and therefore unlimited behavior — the
+// validation-not-stricter-than-runtime guarantee in struct-field form.
+func TestDynamoDB_ZeroValue_HardCapsAreUnlimited(t *testing.T) {
+	d := &DynamoDB{TableName: "live-edc-tran-2026-06"}
+	if d.MaxQueryPaginationPageWalk != 0 {
+		t.Errorf("zero-value MaxQueryPaginationPageWalk = %d, want 0", d.MaxQueryPaginationPageWalk)
+	}
+	if d.MaxQueryPagedItems != 0 {
+		t.Errorf("zero-value MaxQueryPagedItems = %d, want 0", d.MaxQueryPagedItems)
+	}
+	if exceedsHardCap(1<<62, d.MaxQueryPaginationPageWalk) || exceedsHardCap(1<<62, d.MaxQueryPagedItems) {
+		t.Error("zero-value caps must be unlimited — existing callers must behave byte-identically to today")
+	}
+}
+
+// TestWarnDefaults_ContractPin locks the soft-WARN defaults agreed with the
+// operator (1000 pages / 100000 items). These are early-visibility thresholds,
+// far above today's ~49-item partitions; changing them is a deliberate decision,
+// not an accidental refactor — hence the pin, mirroring TestMaxTransactItems_ContractPin.
+func TestWarnDefaults_ContractPin(t *testing.T) {
+	if defaultWarnPaginationPageWalk != 1000 {
+		t.Errorf("defaultWarnPaginationPageWalk = %d, want 1000", defaultWarnPaginationPageWalk)
+	}
+	if defaultWarnPagedItems != 100000 {
+		t.Errorf("defaultWarnPagedItems = %d, want 100000", defaultWarnPagedItems)
+	}
+}

--- a/wrapper/dynamodb/dynamodb_prewalk_failstop_test.go
+++ b/wrapper/dynamodb/dynamodb_prewalk_failstop_test.go
@@ -46,6 +46,7 @@ package dynamodb
 
 import (
 	"errors"
+	"fmt"
 	"strings"
 	"testing"
 )
@@ -253,5 +254,107 @@ func TestWarnDefaults_ContractPin(t *testing.T) {
 	}
 	if defaultWarnPagedItems != 100000 {
 		t.Errorf("defaultWarnPagedItems = %d, want 100000", defaultWarnPagedItems)
+	}
+}
+
+// =============================================================================
+// Remediation of contrarian-review findings (detection-contract + boundary)
+// =============================================================================
+
+// TestDynamoDBError_Unwrap_ResultSetTooLarge pins the detectability fix for the
+// *DynamoDBError boundary. The WithRetry entry points return *DynamoDBError; a
+// caller (incl. the crud layer wrapping with %w) must be able to use
+// errors.Is(err, ErrResultSetTooLarge). Since the struct is flat, Unwrap() must
+// surface the sentinel exactly when the ResultSetTooLarge flag is set, and never
+// otherwise (so unrelated *DynamoDBError values don't spuriously match).
+func TestDynamoDBError_Unwrap_ResultSetTooLarge(t *testing.T) {
+	capped := &DynamoDBError{ErrorMessage: "x", ResultSetTooLarge: true}
+	if !errors.Is(capped, ErrResultSetTooLarge) {
+		t.Error("errors.Is(*DynamoDBError{ResultSetTooLarge:true}, ErrResultSetTooLarge) = false, want true")
+	}
+	// and through a %w wrapper, as the crud layer now wraps it
+	wrapped := fmt.Errorf("crud layer: %w", capped)
+	if !errors.Is(wrapped, ErrResultSetTooLarge) {
+		t.Error("errors.Is through %w wrapper = false, want true — crud-layer detection broken")
+	}
+	ordinary := &DynamoDBError{ErrorMessage: "some other failure"}
+	if errors.Is(ordinary, ErrResultSetTooLarge) {
+		t.Error("an ordinary *DynamoDBError must NOT match ErrResultSetTooLarge")
+	}
+}
+
+// TestRewrapNonRetryable_PreservesFlags guards the P1 bug the contrarian review
+// found: QueryPaginationDataWithRetry re-wrapped a non-retryable *DynamoDBError
+// into a fresh one that copied ONLY ErrorMessage, silently dropping
+// ResultSetTooLarge (and TransactionConditionalCheckFailed). The detection flag
+// is the documented mechanism on this path, so it MUST survive the re-wrap.
+func TestRewrapNonRetryable_PreservesFlags(t *testing.T) {
+	src := &DynamoDBError{
+		ErrorMessage:                      "do_Query... fail-stop",
+		ResultSetTooLarge:                 true,
+		TransactionConditionalCheckFailed: true,
+	}
+	got := rewrapNonRetryable("QueryPaginationDataWithRetry Failed: ", src)
+	if got == nil {
+		t.Fatal("rewrapNonRetryable returned nil")
+	}
+	if !got.ResultSetTooLarge {
+		t.Error("ResultSetTooLarge dropped by re-wrap — the exact P1 bug this guards")
+	}
+	if !got.TransactionConditionalCheckFailed {
+		t.Error("TransactionConditionalCheckFailed dropped by re-wrap")
+	}
+	if got.AllowRetry {
+		t.Error("re-wrapped non-retryable error must keep AllowRetry=false")
+	}
+	if !strings.Contains(got.ErrorMessage, "QueryPaginationDataWithRetry Failed:") || !strings.Contains(got.ErrorMessage, "fail-stop") {
+		t.Errorf("ErrorMessage = %q, want prefix + original", got.ErrorMessage)
+	}
+	if !errors.Is(got, ErrResultSetTooLarge) {
+		t.Error("re-wrapped error must remain errors.Is-detectable via Unwrap")
+	}
+}
+
+// TestFailStopOnMorePages pins the boundary fix: a fail-stop must fire ONLY when
+// the result set is incomplete (more pages remain beyond the cap). A complete
+// result set whose size lands exactly on the cap is NOT an error — failing it
+// would reject a fully-retrieved, legitimately-complete query (the
+// validation-not-stricter-than-runtime trap, and the cap-of-1 / zero-result
+// false-positive the contrarian review flagged).
+func TestFailStopOnMorePages(t *testing.T) {
+	const capLimit = int64(100)
+	cases := []struct {
+		name      string
+		count     int64
+		morePages bool
+		want      bool
+	}{
+		{"at cap, more pages remain -> fail-stop", 100, true, true},
+		{"over cap, more pages remain -> fail-stop", 250, true, true},
+		{"exactly at cap but COMPLETE -> no fail (never reject a complete set)", 100, false, false},
+		{"over cap but COMPLETE -> no fail", 250, false, false},
+		{"under cap, more pages -> no fail", 99, true, false},
+	}
+	for _, c := range cases {
+		if got := failStopOnMorePages(c.count, capLimit, c.morePages); got != c.want {
+			t.Errorf("%s: failStopOnMorePages(%d, %d, %v) = %v, want %v", c.name, c.count, capLimit, c.morePages, got, c.want)
+		}
+	}
+	// cap=0 (unlimited) never fails, even with more pages
+	if failStopOnMorePages(1<<62, 0, true) {
+		t.Error("cap=0 must be unlimited even when more pages remain")
+	}
+}
+
+// TestScanFailStop_ZeroValueUnlimited pins that the new Scan caps default to 0 =
+// unlimited (same backward-compat contract as the query caps), so the existing
+// ScanPagedItemsWithRetry behavior is preserved for every caller that sets nothing.
+func TestScanFailStop_ZeroValueUnlimited(t *testing.T) {
+	d := &DynamoDB{TableName: "live-edc-tran-2026-06"}
+	if d.MaxScanPagedItems != 0 {
+		t.Errorf("zero-value MaxScanPagedItems = %d, want 0", d.MaxScanPagedItems)
+	}
+	if failStopOnMorePages(1<<62, d.MaxScanPagedItems, true) {
+		t.Error("zero-value scan cap must be unlimited")
 	}
 }


### PR DESCRIPTION
## Summary

Two read paths in `wrapper/dynamodb` are **unbounded** and shared by every DAL service:

- **`do_Query_Pagination_Data`** (drives `QueryPaginationData*`) — walks **every page** of a query just to collect each page's `ExclusiveStartKey` → `O(total / itemsPerPage)` DynamoDB round-trips per list call.
- **`QueryPagedItemsWithRetry`** (reached by `crud.Query` when `itemsPerPage <= 0`) — accumulates **every matching item** into one in-memory slice.

Both are latent **O(N) / OOM bombs**: harmless while partitions are tiny, fatal for a large partition (one task pinned on round-trips or OOM'd on a giant gather).

This adds an **opt-in fail-stop** — **not truncation**. Silent truncation of a payment-transaction list is a data-integrity regression, so when a cap is reached the call returns the typed sentinel `ErrResultSetTooLarge` and **discards the partial result** — it never returns a short slice.

## What's added (all in `wrapper/dynamodb/dynamodb.go`)

- **Sentinel** `ErrResultSetTooLarge` (wrapped via `%w`) + new flat-struct flag `DynamoDBError.ResultSetTooLarge` (the struct has no `Unwrap`; mirrors the existing `TransactionConditionalCheckFailed` idiom).
- **Opt-in `DynamoDB` struct fields** (mirror the existing `DisableLastExecuteParamsPayload` "default preserves the observable contract" idiom):
  - `MaxQueryPaginationPageWalk`, `MaxQueryPagedItems` — `int64`, **default `0` = unlimited** (hard fail-stop when > 0).
  - `WarnQueryPaginationPageWalk`, `WarnQueryPagedItems` — `int64`, **`0` = built-in default** (`1000` pages / `100000` items), `< 0` = disabled, `> 0` = custom. A soft `[WARN]` at the crossing, **never fails the call**.
- Pure, unit-tested decision helpers: `exceedsHardCap`, `effectiveWarnThreshold`, `shouldWarnAtCrossing`, `newResultSetTooLargeError`.

## Backward compatibility (the hard constraint)

Default `0 = unlimited`, so **every existing caller behaves byte-identically to today** — the cap is dormant until a caller opts in. This is deliberate: the cap value high enough to never break a legitimate large caller (e.g. a high-volume merchant's monthly reconcile) is *also* high enough to still OOM, so a global hard default would be self-defeating and would convert a tolerated input into a hard failure. **Opt in per-table, above that table's measured maximum partition size.** The soft `[WARN]` (zero functional consequence) carries a baked default so every service still gets early visibility of a growing partition.

## No retry amplification

`ErrResultSetTooLarge` is a non-AWS error, so `handleError` keeps `AllowRetry = false` and `QueryPaginationDataWithRetry` does **not** re-walk the (deterministic) over-cap result. Pinned by test.

## Detection

- Plain-error path (`QueryPagedItemsWithRetry`): `errors.Is(err, ErrResultSetTooLarge)`.
- `*WithRetry` (`*DynamoDBError`) path: `ddbErr.ResultSetTooLarge`.

## Tests

`wrapper/dynamodb/dynamodb_prewalk_failstop_test.go` — deterministic, no AWS connection required (mirrors `dynamodb_contract_test.go` conventions): cap/warn-crossing boundaries, sentinel `errors.Is` detectability, `handleError` flag + non-retryable pin, zero-value-struct = unlimited (backward-compat pin), WARN-default contract pins.

- `go build ./...` — clean
- `go vet ./wrapper/dynamodb/` — clean
- `go test ./wrapper/dynamodb/ -race` — ok (new tests + all pre-existing contract tests)
- whole-module `go test ./... -short` — **55 ok / 0 fail** (zero regressions)