### PR TITLE
fix(dynamodb): exponential backoff for *WithRetry; InternalServerError backs off

### DIFF
--- a/wrapper/dynamodb/dynamodb.go
+++ b/wrapper/dynamodb/dynamodb.go
@@ -895,6 +895,14 @@ type DynamoDB struct {
 	// Default false preserves the v1.8.6 observable contract.
 	DisableLastExecuteParamsPayload bool
 
+	// UseLegacyFlatRetryDelay, when true, restores the pre-exponential-backoff
+	// retry behavior: a FIXED inter-retry sleep (500ms when the error needs
+	// backoff, 100ms otherwise) AND the pre-change InternalServerError
+	// classification (retry-WITHOUT-backoff). It exists as a migration escape
+	// hatch for callers whose timeout budget was calibrated to the old flat
+	// schedule. Default false uses the exponential backoff AWS recommends.
+	UseLegacyFlatRetryDelay bool
+
 	_parentSegment      *xray.XRayParentSegment
 	_parentSegmentMutex sync.RWMutex
 }
@@ -950,6 +958,32 @@ func (d *DynamoDB) connectionSnapshot() (cn *dynamodb.DynamoDB, cnDax *dax.Dax, 
 	}
 }
 
+// legacyFlatBackoffDelay / legacyFlatNoBackoffDelay are the pre-exponential fixed
+// inter-retry sleeps, restored when DynamoDB.UseLegacyFlatRetryDelay is set.
+const (
+	legacyFlatBackoffDelay   = 500 * time.Millisecond
+	legacyFlatNoBackoffDelay = 100 * time.Millisecond
+)
+
+// retryDelay resolves the inter-retry sleep for a *WithRetry method. By default it
+// uses the exponential schedule (retryBackoffDelay). When the caller opted into
+// UseLegacyFlatRetryDelay, it returns the pre-change fixed delay instead so a
+// migration-window consumer keeps the old timing. Kept as a thin method (rather
+// than threading the flag through retryBackoffDelay) so the exponential math stays
+// a pure, independently-tested function.
+func (d *DynamoDB) retryDelay(remainingRetries uint, needsBackOff bool) time.Duration {
+	if d != nil && d.UseLegacyFlatRetryDelay {
+		if remainingRetries == 0 {
+			return 0
+		}
+		if needsBackOff {
+			return legacyFlatBackoffDelay
+		}
+		return legacyFlatNoBackoffDelay
+	}
+	return retryBackoffDelay(remainingRetries, needsBackOff)
+}
+
 // retryBackoffDelay returns how long a *WithRetry method should sleep before its
 // next attempt. The *WithRetry methods recurse with maxRetries-1, so the delay is
 // derived from the DEPLETING budget (remainingRetries) rather than an attempt
@@ -972,7 +1006,7 @@ func retryBackoffDelay(remainingRetries uint, needsBackOff bool) time.Duration {
 		remainingRetries = 10
 	}
 
-	ceiling := 4 * time.Second // needsBackOff: final-retry (remaining==1) delay = 2s, matching the BatchWrite UnprocessedItems backoff cap
+	ceiling := 4 * time.Second // needsBackOff: final-retry (remaining==1) delay = 2s, matching the BatchWrite UnprocessedItems backoff CAP (the ramp shape differs — this floors early attempts rather than doubling from a fixed base)
 	floor := 100 * time.Millisecond
 	if !needsBackOff {
 		ceiling = 1 * time.Second // transient: final-retry delay = 500ms
@@ -1125,11 +1159,13 @@ func (d *DynamoDB) handleError(err error, errorPrefix ...string) *DynamoDBError 
 		case dynamodb.ErrCodeInternalServerError:
 			// transient server-side fault — AWS recommends retry with EXPONENTIAL
 			// BACKOFF (not immediate); a flat fast retry hammers the partition.
+			// UseLegacyFlatRetryDelay restores the pre-change immediate-retry
+			// classification so a migration-window caller keeps master ISE timing.
 			return &DynamoDBError{
 				ErrorMessage:                      prefix + prefixType + aerr.Code() + " - " + aerr.Message() + " - " + origError,
 				SuppressError:                     true,
 				AllowRetry:                        true,
-				RetryNeedsBackOff:                 true,
+				RetryNeedsBackOff:                 !d.UseLegacyFlatRetryDelay,
 				TransactionConditionalCheckFailed: false,
 			}
 
@@ -3154,7 +3190,7 @@ func (d *DynamoDB) PutItemWithRetry(maxRetries uint, item interface{}, timeOutDu
 		// has error
 		if maxRetries > 0 {
 			if err.AllowRetry {
-				time.Sleep(retryBackoffDelay(maxRetries, err.RetryNeedsBackOff))
+				time.Sleep(d.retryDelay(maxRetries, err.RetryNeedsBackOff))
 
 				log.Println("PutItemWithRetry Failed: " + err.ErrorMessage)
 				return d.PutItemWithRetry(maxRetries-1, item, util.DurationPtr(timeout), conditionExpressionSet...)
@@ -3603,7 +3639,7 @@ func (d *DynamoDB) UpdateItemWithRetry(maxRetries uint,
 		// has error
 		if maxRetries > 0 {
 			if err.AllowRetry {
-				time.Sleep(retryBackoffDelay(maxRetries, err.RetryNeedsBackOff))
+				time.Sleep(d.retryDelay(maxRetries, err.RetryNeedsBackOff))
 
 				log.Println("UpdateItemWithRetry Failed: " + err.ErrorMessage)
 				return d.UpdateItemWithRetry(maxRetries-1, pkValue, skValue, updateExpression, conditionExpression, expressionAttributeNames, expressionAttributeValues, util.DurationPtr(timeout))
@@ -3903,7 +3939,7 @@ func (d *DynamoDB) RemoveItemAttributeWithRetry(maxRetries uint, pkValue string,
 		// has error
 		if maxRetries > 0 {
 			if err.AllowRetry {
-				time.Sleep(retryBackoffDelay(maxRetries, err.RetryNeedsBackOff))
+				time.Sleep(d.retryDelay(maxRetries, err.RetryNeedsBackOff))
 
 				log.Println("RemoveItemAttributeWithRetry Failed: " + err.ErrorMessage)
 				return d.RemoveItemAttributeWithRetry(maxRetries-1, pkValue, skValue, removeExpression, util.DurationPtr(timeout), conditionExpressionSet...)
@@ -4165,7 +4201,7 @@ func (d *DynamoDB) DeleteItemWithRetry(maxRetries uint, pkValue string, skValue 
 		// has error
 		if maxRetries > 0 {
 			if err.AllowRetry {
-				time.Sleep(retryBackoffDelay(maxRetries, err.RetryNeedsBackOff))
+				time.Sleep(d.retryDelay(maxRetries, err.RetryNeedsBackOff))
 
 				log.Println("DeleteItemWithRetry Failed: " + err.ErrorMessage)
 				return d.DeleteItemWithRetry(maxRetries-1, pkValue, skValue, util.DurationPtr(timeout))
@@ -4603,7 +4639,7 @@ func (d *DynamoDB) GetItemWithRetry(maxRetries uint,
 		// has error
 		if maxRetries > 0 {
 			if err.AllowRetry {
-				time.Sleep(retryBackoffDelay(maxRetries, err.RetryNeedsBackOff))
+				time.Sleep(d.retryDelay(maxRetries, err.RetryNeedsBackOff))
 
 				log.Println("GetItemWithRetry Failed: " + err.ErrorMessage)
 				return d.GetItemWithRetry(maxRetries-1, resultItemPtr, pkValue, skValue, util.DurationPtr(timeout), consistentRead, projectedAttributes...)
@@ -4683,7 +4719,7 @@ func (d *DynamoDB) QueryPaginationDataWithRetry(
 		// has error
 		if maxRetries > 0 {
 			if ddbErr.AllowRetry {
-				time.Sleep(retryBackoffDelay(maxRetries, ddbErr.RetryNeedsBackOff))
+				time.Sleep(d.retryDelay(maxRetries, ddbErr.RetryNeedsBackOff))
 
 				log.Println("QueryPaginationDataWithRetry Failed: " + ddbErr.ErrorMessage)
 				return d.QueryPaginationDataWithRetry(maxRetries-1, util.DurationPtr(timeout), indexName, itemsPerPage, keyConditionExpression, expressionAttributeNames, expressionAttributeValues)
@@ -5615,7 +5651,7 @@ func (d *DynamoDB) QueryItemsWithRetry(maxRetries uint,
 		// has error
 		if maxRetries > 0 {
 			if ddbErr.AllowRetry {
-				time.Sleep(retryBackoffDelay(maxRetries, ddbErr.RetryNeedsBackOff))
+				time.Sleep(d.retryDelay(maxRetries, ddbErr.RetryNeedsBackOff))
 
 				log.Println("QueryItemsWithRetry Failed: " + ddbErr.ErrorMessage)
 				return d.QueryItemsWithRetry(maxRetries-1,
@@ -6404,7 +6440,7 @@ func (d *DynamoDB) ScanItemsWithRetry(maxRetries uint,
 		// has error
 		if maxRetries > 0 {
 			if ddbErr.AllowRetry {
-				time.Sleep(retryBackoffDelay(maxRetries, ddbErr.RetryNeedsBackOff))
+				time.Sleep(d.retryDelay(maxRetries, ddbErr.RetryNeedsBackOff))
 
 				log.Println("ScanItemsWithRetry Failed: " + ddbErr.ErrorMessage)
 				return d.ScanItemsWithRetry(maxRetries-1,
@@ -7289,7 +7325,7 @@ func (d *DynamoDB) BatchWriteItemsWithRetry(maxRetries uint,
 		// has error
 		if maxRetries > 0 {
 			if err.AllowRetry {
-				time.Sleep(retryBackoffDelay(maxRetries, err.RetryNeedsBackOff))
+				time.Sleep(d.retryDelay(maxRetries, err.RetryNeedsBackOff))
 
 				log.Println("BatchWriteItemsWithRetry Failed: " + err.ErrorMessage)
 				return d.BatchWriteItemsWithRetry(maxRetries-1, putItemsSet, deleteKeys, util.DurationPtr(timeout))
@@ -8080,7 +8116,7 @@ func (d *DynamoDB) BatchGetItemsWithRetry(maxRetries uint, timeOutDuration *time
 		// has error
 		if maxRetries > 0 {
 			if err.AllowRetry {
-				time.Sleep(retryBackoffDelay(maxRetries, err.RetryNeedsBackOff))
+				time.Sleep(d.retryDelay(maxRetries, err.RetryNeedsBackOff))
 
 				log.Println("BatchGetItemsWithRetry Failed: " + err.ErrorMessage)
 				return d.BatchGetItemsWithRetry(maxRetries-1, util.DurationPtr(timeout), multiGetRequestResponse...)
@@ -8663,7 +8699,7 @@ func (d *DynamoDB) TransactionWriteItemsWithRetry(maxRetries uint,
 		// has error
 		if maxRetries > 0 {
 			if err.AllowRetry {
-				time.Sleep(retryBackoffDelay(maxRetries, err.RetryNeedsBackOff))
+				time.Sleep(d.retryDelay(maxRetries, err.RetryNeedsBackOff))
 
 				log.Println("TransactionWriteItemsWithRetry Failed: " + err.ErrorMessage)
 				return d.TransactionWriteItemsWithRetry(maxRetries-1, util.DurationPtr(timeout), tranItems...)
@@ -9236,7 +9272,7 @@ func (d *DynamoDB) TransactionGetItemsWithRetry(maxRetries uint,
 		// has error
 		if maxRetries > 0 {
 			if err.AllowRetry {
-				time.Sleep(retryBackoffDelay(maxRetries, err.RetryNeedsBackOff))
+				time.Sleep(d.retryDelay(maxRetries, err.RetryNeedsBackOff))
 
 				log.Println("TransactionGetItemsWithRetry Failed: " + err.ErrorMessage)
 				return d.TransactionGetItemsWithRetry(maxRetries-1, util.DurationPtr(timeout), getItems...)

--- a/wrapper/dynamodb/dynamodb.go
+++ b/wrapper/dynamodb/dynamodb.go
@@ -82,7 +82,8 @@ import (
 // (see MaxBatchWriteItems below).
 //
 // Source: https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_TransactWriteItems.html
-//         https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_TransactGetItems.html
+//
+//	https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_TransactGetItems.html
 const MaxTransactItems = 100
 
 // MaxBatchWriteItems is the maximum number of items allowed in a single
@@ -949,6 +950,42 @@ func (d *DynamoDB) connectionSnapshot() (cn *dynamodb.DynamoDB, cnDax *dax.Dax, 
 	}
 }
 
+// retryBackoffDelay returns how long a *WithRetry method should sleep before its
+// next attempt. The *WithRetry methods recurse with maxRetries-1, so the delay is
+// derived from the DEPLETING budget (remainingRetries) rather than an attempt
+// counter — no signature change required. delay = ceiling >> remainingRetries,
+// which DOUBLES each step as remainingRetries shrinks, producing classic
+// exponential backoff that is naturally capped at ceiling/2 on the final retry
+// (remainingRetries==1) and floored so early attempts of a large budget still
+// pause. Throttle/5xx (needsBackOff) use a higher ceiling than the transient
+// no-backoff path. remainingRetries is clamped to the same [0,10] band the
+// *WithRetry methods clamp maxRetries to.
+//
+// Previously every retry slept a FIXED 500ms (backoff) or 100ms (no-backoff);
+// under sustained throttling that let many callers retry in lockstep (thundering
+// herd) and never ramped, contrary to the AWS DynamoDB retry guidance.
+func retryBackoffDelay(remainingRetries uint, needsBackOff bool) time.Duration {
+	if remainingRetries == 0 {
+		return 0
+	}
+	if remainingRetries > 10 {
+		remainingRetries = 10
+	}
+
+	ceiling := 4 * time.Second // needsBackOff: final-retry (remaining==1) delay = 2s, matching the BatchWrite UnprocessedItems backoff cap
+	floor := 100 * time.Millisecond
+	if !needsBackOff {
+		ceiling = 1 * time.Second // transient: final-retry delay = 500ms
+		floor = 50 * time.Millisecond
+	}
+
+	delay := ceiling >> remainingRetries
+	if delay < floor {
+		delay = floor
+	}
+	return delay
+}
+
 // handleError is an internal helper method to evaluate dynamodb error,
 // and to advise if retry, immediate retry, suppress error etc error handling advisory
 //
@@ -1086,12 +1123,13 @@ func (d *DynamoDB) handleError(err error, errorPrefix ...string) *DynamoDBError 
 			}
 
 		case dynamodb.ErrCodeInternalServerError:
-			// no error + allow auto retry without backoff
+			// transient server-side fault — AWS recommends retry with EXPONENTIAL
+			// BACKOFF (not immediate); a flat fast retry hammers the partition.
 			return &DynamoDBError{
 				ErrorMessage:                      prefix + prefixType + aerr.Code() + " - " + aerr.Message() + " - " + origError,
 				SuppressError:                     true,
 				AllowRetry:                        true,
-				RetryNeedsBackOff:                 false,
+				RetryNeedsBackOff:                 true,
 				TransactionConditionalCheckFailed: false,
 			}
 
@@ -3116,11 +3154,7 @@ func (d *DynamoDB) PutItemWithRetry(maxRetries uint, item interface{}, timeOutDu
 		// has error
 		if maxRetries > 0 {
 			if err.AllowRetry {
-				if err.RetryNeedsBackOff {
-					time.Sleep(500 * time.Millisecond)
-				} else {
-					time.Sleep(100 * time.Millisecond)
-				}
+				time.Sleep(retryBackoffDelay(maxRetries, err.RetryNeedsBackOff))
 
 				log.Println("PutItemWithRetry Failed: " + err.ErrorMessage)
 				return d.PutItemWithRetry(maxRetries-1, item, util.DurationPtr(timeout), conditionExpressionSet...)
@@ -3569,11 +3603,7 @@ func (d *DynamoDB) UpdateItemWithRetry(maxRetries uint,
 		// has error
 		if maxRetries > 0 {
 			if err.AllowRetry {
-				if err.RetryNeedsBackOff {
-					time.Sleep(500 * time.Millisecond)
-				} else {
-					time.Sleep(100 * time.Millisecond)
-				}
+				time.Sleep(retryBackoffDelay(maxRetries, err.RetryNeedsBackOff))
 
 				log.Println("UpdateItemWithRetry Failed: " + err.ErrorMessage)
 				return d.UpdateItemWithRetry(maxRetries-1, pkValue, skValue, updateExpression, conditionExpression, expressionAttributeNames, expressionAttributeValues, util.DurationPtr(timeout))
@@ -3873,11 +3903,7 @@ func (d *DynamoDB) RemoveItemAttributeWithRetry(maxRetries uint, pkValue string,
 		// has error
 		if maxRetries > 0 {
 			if err.AllowRetry {
-				if err.RetryNeedsBackOff {
-					time.Sleep(500 * time.Millisecond)
-				} else {
-					time.Sleep(100 * time.Millisecond)
-				}
+				time.Sleep(retryBackoffDelay(maxRetries, err.RetryNeedsBackOff))
 
 				log.Println("RemoveItemAttributeWithRetry Failed: " + err.ErrorMessage)
 				return d.RemoveItemAttributeWithRetry(maxRetries-1, pkValue, skValue, removeExpression, util.DurationPtr(timeout), conditionExpressionSet...)
@@ -4139,11 +4165,7 @@ func (d *DynamoDB) DeleteItemWithRetry(maxRetries uint, pkValue string, skValue 
 		// has error
 		if maxRetries > 0 {
 			if err.AllowRetry {
-				if err.RetryNeedsBackOff {
-					time.Sleep(500 * time.Millisecond)
-				} else {
-					time.Sleep(100 * time.Millisecond)
-				}
+				time.Sleep(retryBackoffDelay(maxRetries, err.RetryNeedsBackOff))
 
 				log.Println("DeleteItemWithRetry Failed: " + err.ErrorMessage)
 				return d.DeleteItemWithRetry(maxRetries-1, pkValue, skValue, util.DurationPtr(timeout))
@@ -4581,11 +4603,7 @@ func (d *DynamoDB) GetItemWithRetry(maxRetries uint,
 		// has error
 		if maxRetries > 0 {
 			if err.AllowRetry {
-				if err.RetryNeedsBackOff {
-					time.Sleep(500 * time.Millisecond)
-				} else {
-					time.Sleep(100 * time.Millisecond)
-				}
+				time.Sleep(retryBackoffDelay(maxRetries, err.RetryNeedsBackOff))
 
 				log.Println("GetItemWithRetry Failed: " + err.ErrorMessage)
 				return d.GetItemWithRetry(maxRetries-1, resultItemPtr, pkValue, skValue, util.DurationPtr(timeout), consistentRead, projectedAttributes...)
@@ -4665,11 +4683,7 @@ func (d *DynamoDB) QueryPaginationDataWithRetry(
 		// has error
 		if maxRetries > 0 {
 			if ddbErr.AllowRetry {
-				if ddbErr.RetryNeedsBackOff {
-					time.Sleep(500 * time.Millisecond)
-				} else {
-					time.Sleep(100 * time.Millisecond)
-				}
+				time.Sleep(retryBackoffDelay(maxRetries, ddbErr.RetryNeedsBackOff))
 
 				log.Println("QueryPaginationDataWithRetry Failed: " + ddbErr.ErrorMessage)
 				return d.QueryPaginationDataWithRetry(maxRetries-1, util.DurationPtr(timeout), indexName, itemsPerPage, keyConditionExpression, expressionAttributeNames, expressionAttributeValues)
@@ -5601,11 +5615,7 @@ func (d *DynamoDB) QueryItemsWithRetry(maxRetries uint,
 		// has error
 		if maxRetries > 0 {
 			if ddbErr.AllowRetry {
-				if ddbErr.RetryNeedsBackOff {
-					time.Sleep(500 * time.Millisecond)
-				} else {
-					time.Sleep(100 * time.Millisecond)
-				}
+				time.Sleep(retryBackoffDelay(maxRetries, ddbErr.RetryNeedsBackOff))
 
 				log.Println("QueryItemsWithRetry Failed: " + ddbErr.ErrorMessage)
 				return d.QueryItemsWithRetry(maxRetries-1,
@@ -6394,11 +6404,7 @@ func (d *DynamoDB) ScanItemsWithRetry(maxRetries uint,
 		// has error
 		if maxRetries > 0 {
 			if ddbErr.AllowRetry {
-				if ddbErr.RetryNeedsBackOff {
-					time.Sleep(500 * time.Millisecond)
-				} else {
-					time.Sleep(100 * time.Millisecond)
-				}
+				time.Sleep(retryBackoffDelay(maxRetries, ddbErr.RetryNeedsBackOff))
 
 				log.Println("ScanItemsWithRetry Failed: " + ddbErr.ErrorMessage)
 				return d.ScanItemsWithRetry(maxRetries-1,
@@ -7283,11 +7289,7 @@ func (d *DynamoDB) BatchWriteItemsWithRetry(maxRetries uint,
 		// has error
 		if maxRetries > 0 {
 			if err.AllowRetry {
-				if err.RetryNeedsBackOff {
-					time.Sleep(500 * time.Millisecond)
-				} else {
-					time.Sleep(100 * time.Millisecond)
-				}
+				time.Sleep(retryBackoffDelay(maxRetries, err.RetryNeedsBackOff))
 
 				log.Println("BatchWriteItemsWithRetry Failed: " + err.ErrorMessage)
 				return d.BatchWriteItemsWithRetry(maxRetries-1, putItemsSet, deleteKeys, util.DurationPtr(timeout))
@@ -8078,11 +8080,7 @@ func (d *DynamoDB) BatchGetItemsWithRetry(maxRetries uint, timeOutDuration *time
 		// has error
 		if maxRetries > 0 {
 			if err.AllowRetry {
-				if err.RetryNeedsBackOff {
-					time.Sleep(500 * time.Millisecond)
-				} else {
-					time.Sleep(100 * time.Millisecond)
-				}
+				time.Sleep(retryBackoffDelay(maxRetries, err.RetryNeedsBackOff))
 
 				log.Println("BatchGetItemsWithRetry Failed: " + err.ErrorMessage)
 				return d.BatchGetItemsWithRetry(maxRetries-1, util.DurationPtr(timeout), multiGetRequestResponse...)
@@ -8665,11 +8663,7 @@ func (d *DynamoDB) TransactionWriteItemsWithRetry(maxRetries uint,
 		// has error
 		if maxRetries > 0 {
 			if err.AllowRetry {
-				if err.RetryNeedsBackOff {
-					time.Sleep(500 * time.Millisecond)
-				} else {
-					time.Sleep(100 * time.Millisecond)
-				}
+				time.Sleep(retryBackoffDelay(maxRetries, err.RetryNeedsBackOff))
 
 				log.Println("TransactionWriteItemsWithRetry Failed: " + err.ErrorMessage)
 				return d.TransactionWriteItemsWithRetry(maxRetries-1, util.DurationPtr(timeout), tranItems...)
@@ -9242,11 +9236,7 @@ func (d *DynamoDB) TransactionGetItemsWithRetry(maxRetries uint,
 		// has error
 		if maxRetries > 0 {
 			if err.AllowRetry {
-				if err.RetryNeedsBackOff {
-					time.Sleep(500 * time.Millisecond)
-				} else {
-					time.Sleep(100 * time.Millisecond)
-				}
+				time.Sleep(retryBackoffDelay(maxRetries, err.RetryNeedsBackOff))
 
 				log.Println("TransactionGetItemsWithRetry Failed: " + err.ErrorMessage)
 				return d.TransactionGetItemsWithRetry(maxRetries-1, util.DurationPtr(timeout), getItems...)

--- a/wrapper/dynamodb/dynamodb_retry_backoff_test.go
+++ b/wrapper/dynamodb/dynamodb_retry_backoff_test.go
@@ -1,0 +1,120 @@
+package dynamodb
+
+/*
+ * Copyright 2020-2026 Aldelo, LP
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Pins the retry backoff schedule. The *WithRetry methods previously slept a
+// FIXED 500ms (backoff) or 100ms (no-backoff) on every attempt — not the
+// exponential backoff AWS recommends, which under sustained throttling lets many
+// callers retry in lockstep (thundering herd). retryBackoffDelay replaces the flat
+// sleeps with an exponentially growing delay derived from the depleting retry
+// budget (no signature change to the recursive methods). These tests pin the
+// schedule's shape so a future refactor cannot silently flatten it again.
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/service/dynamodb"
+)
+
+// TestRetryBackoffDelay_MonotonicAndExponential verifies the delay grows as the
+// retry budget depletes (remainingRetries decreases on each recursive attempt),
+// doubling in the un-floored region — i.e. real exponential backoff.
+func TestRetryBackoffDelay_MonotonicAndExponential(t *testing.T) {
+	// remainingRetries goes high->low as retries are consumed; delay must be
+	// non-decreasing as remainingRetries decreases.
+	var prev time.Duration
+	for r := uint(10); r >= 1; r-- {
+		d := retryBackoffDelay(r, true)
+		if d < prev {
+			t.Errorf("retryBackoffDelay(%d,true)=%v < previous %v — schedule must be non-decreasing as budget depletes", r, d, prev)
+		}
+		prev = d
+	}
+
+	// doubling in the exponential (un-floored) region for needsBackOff: r=3->500ms, r=2->1s, r=1->2s
+	if got := retryBackoffDelay(3, true); got != 500*time.Millisecond {
+		t.Errorf("retryBackoffDelay(3,true)=%v, want 500ms", got)
+	}
+	if got := retryBackoffDelay(2, true); got != 1*time.Second {
+		t.Errorf("retryBackoffDelay(2,true)=%v, want 1s", got)
+	}
+	if got := retryBackoffDelay(1, true); got != 2*time.Second {
+		t.Errorf("retryBackoffDelay(1,true)=%v, want 2s (final-retry cap)", got)
+	}
+}
+
+// TestRetryBackoffDelay_FlooredCappedClamped pins the floor, the ceiling, and the
+// clamp on remainingRetries.
+func TestRetryBackoffDelay_FlooredCappedClamped(t *testing.T) {
+	// floor: early attempts of a large budget still pause a minimum
+	if got := retryBackoffDelay(10, true); got != 100*time.Millisecond {
+		t.Errorf("retryBackoffDelay(10,true)=%v, want floor 100ms", got)
+	}
+	if got := retryBackoffDelay(10, false); got != 50*time.Millisecond {
+		t.Errorf("retryBackoffDelay(10,false)=%v, want floor 50ms", got)
+	}
+	// ceiling: the largest single delay is the final-retry value
+	if got := retryBackoffDelay(1, true); got > 2*time.Second {
+		t.Errorf("retryBackoffDelay(1,true)=%v exceeds 2s cap", got)
+	}
+	if got := retryBackoffDelay(1, false); got > 500*time.Millisecond {
+		t.Errorf("retryBackoffDelay(1,false)=%v exceeds 500ms cap", got)
+	}
+	// clamp: values above the maxRetries band behave like the band max
+	if retryBackoffDelay(100, true) != retryBackoffDelay(10, true) {
+		t.Error("remainingRetries must be clamped to the [1,10] band (same as maxRetries clamp)")
+	}
+	// zero budget => no sleep
+	if retryBackoffDelay(0, true) != 0 || retryBackoffDelay(0, false) != 0 {
+		t.Error("retryBackoffDelay(0, *) must be 0 — no retry, no sleep")
+	}
+}
+
+// TestRetryBackoffDelay_BackoffExceedsTransient verifies the throttle/5xx path
+// (needsBackOff) waits at least as long as the transient path at every step.
+func TestRetryBackoffDelay_BackoffExceedsTransient(t *testing.T) {
+	for r := uint(1); r <= 10; r++ {
+		bo := retryBackoffDelay(r, true)
+		tr := retryBackoffDelay(r, false)
+		if bo < tr {
+			t.Errorf("at remaining=%d: needsBackOff delay %v < transient delay %v", r, bo, tr)
+		}
+	}
+}
+
+// TestHandleError_InternalServerError_NowBacksOff pins the classification fix:
+// DynamoDB InternalServerError is a transient server fault that AWS says to retry
+// with EXPONENTIAL BACKOFF. It was previously classified retry-WITHOUT-backoff,
+// which under an ISE brownout hammered the partition at a flat 100ms. It must now
+// be AllowRetry + RetryNeedsBackOff.
+func TestHandleError_InternalServerError_NowBacksOff(t *testing.T) {
+	d := &DynamoDB{}
+	aerr := awserr.New(dynamodb.ErrCodeInternalServerError, "test", fmt.Errorf("test"))
+	ddbErr := d.handleError(aerr)
+	if ddbErr == nil {
+		t.Fatal("handleError(InternalServerError) returned nil")
+	}
+	if !ddbErr.AllowRetry {
+		t.Error("InternalServerError must remain AllowRetry=true")
+	}
+	if !ddbErr.RetryNeedsBackOff {
+		t.Error("InternalServerError must now RetryNeedsBackOff=true (AWS recommends exponential backoff for 5xx)")
+	}
+}

--- a/wrapper/dynamodb/dynamodb_retry_backoff_test.go
+++ b/wrapper/dynamodb/dynamodb_retry_backoff_test.go
@@ -146,6 +146,14 @@ func TestRetryDelay_DefaultIsExponential_LegacyFlatRestoresFixed(t *testing.T) {
 			t.Errorf("legacy retryDelay(%d,false)=%v, want flat 100ms", r, got)
 		}
 	}
+
+	// zero budget = no retry = no sleep, in BOTH modes (matches retryBackoffDelay(0,*))
+	if got := def.retryDelay(0, true); got != 0 {
+		t.Errorf("default retryDelay(0,true)=%v, want 0 (no retry, no sleep)", got)
+	}
+	if got := legacy.retryDelay(0, true); got != 0 {
+		t.Errorf("legacy retryDelay(0,true)=%v, want 0 (no retry, no sleep)", got)
+	}
 }
 
 // TestHandleError_InternalServerError_LegacyMode_RestoresImmediateRetry proves the

--- a/wrapper/dynamodb/dynamodb_retry_backoff_test.go
+++ b/wrapper/dynamodb/dynamodb_retry_backoff_test.go
@@ -118,3 +118,57 @@ func TestHandleError_InternalServerError_NowBacksOff(t *testing.T) {
 		t.Error("InternalServerError must now RetryNeedsBackOff=true (AWS recommends exponential backoff for 5xx)")
 	}
 }
+
+// TestRetryDelay_DefaultIsExponential_LegacyFlatRestoresFixed proves the opt-out
+// escape hatch: by default retryDelay uses the new exponential schedule, but a
+// consumer that set UseLegacyFlatRetryDelay=true gets the pre-PR fixed 500ms/100ms
+// schedule back (for a migration window where the new timing breaks a tight
+// caller budget). The two modes must be distinguishable at remainingRetries=1,
+// where exponential = 2s/500ms but legacy-flat = 500ms/100ms.
+func TestRetryDelay_DefaultIsExponential_LegacyFlatRestoresFixed(t *testing.T) {
+	def := &DynamoDB{}
+	legacy := &DynamoDB{UseLegacyFlatRetryDelay: true}
+
+	// default mode delegates to the exponential schedule
+	if got := def.retryDelay(1, true); got != 2*time.Second {
+		t.Errorf("default retryDelay(1,true)=%v, want 2s (exponential final-retry)", got)
+	}
+	if got := def.retryDelay(1, false); got != 500*time.Millisecond {
+		t.Errorf("default retryDelay(1,false)=%v, want 500ms (exponential transient final)", got)
+	}
+
+	// legacy mode is FLAT regardless of remainingRetries — restoring master timing
+	for _, r := range []uint{1, 3, 10} {
+		if got := legacy.retryDelay(r, true); got != 500*time.Millisecond {
+			t.Errorf("legacy retryDelay(%d,true)=%v, want flat 500ms", r, got)
+		}
+		if got := legacy.retryDelay(r, false); got != 100*time.Millisecond {
+			t.Errorf("legacy retryDelay(%d,false)=%v, want flat 100ms", r, got)
+		}
+	}
+}
+
+// TestHandleError_InternalServerError_LegacyMode_RestoresImmediateRetry proves the
+// escape hatch ALSO reverts the ISE classification, not just the delay curve.
+// Master classified ISE as retry-WITHOUT-backoff (immediate 100ms). For a legacy
+// consumer to get true master parity on ISE, handleError must keep
+// RetryNeedsBackOff=false in legacy mode — otherwise ISE would route to the
+// backoff path and sleep 500ms (legacy flat) instead of master's 100ms.
+func TestHandleError_InternalServerError_LegacyMode_RestoresImmediateRetry(t *testing.T) {
+	d := &DynamoDB{UseLegacyFlatRetryDelay: true}
+	aerr := awserr.New(dynamodb.ErrCodeInternalServerError, "test", fmt.Errorf("test"))
+	ddbErr := d.handleError(aerr)
+	if ddbErr == nil {
+		t.Fatal("handleError(InternalServerError) returned nil")
+	}
+	if !ddbErr.AllowRetry {
+		t.Error("InternalServerError must remain AllowRetry=true even in legacy mode")
+	}
+	if ddbErr.RetryNeedsBackOff {
+		t.Error("legacy mode must restore ISE RetryNeedsBackOff=false (master immediate-retry parity)")
+	}
+	// full master-parity chain: ISE -> needsBackOff=false -> legacy flat 100ms
+	if got := d.retryDelay(3, ddbErr.RetryNeedsBackOff); got != 100*time.Millisecond {
+		t.Errorf("legacy ISE delay=%v, want 100ms (master parity)", got)
+	}
+}


### PR DESCRIPTION
## Problem
The 12 recursive `*WithRetry` methods slept a **fixed** 500ms (backoff) or 100ms (no-backoff) on every attempt — not the exponential backoff AWS recommends. Under sustained throttling this lets many callers retry in lockstep (thundering herd) and never ramps. Separately, `InternalServerError` (a transient 5xx) was classified retry-**without**-backoff, so an ISE brownout was hammered at a flat 100ms.

The codebase already has the correct pattern in `BatchWriteItemsWithRetry`'s UnprocessedItems loop (doubling, capped at 2s); this PR applies it to the recursive methods.

## Change
- **`retryBackoffDelay(remainingRetries, needsBackOff)`**: `delay = ceiling >> remainingRetries`, which **doubles** each step as the retry budget depletes. The methods recurse with `maxRetries-1`, so deriving the delay from the *remaining* budget needs **no signature change**. Floored so early attempts of a large budget still pause; final-retry cap **2s** (backoff) / **500ms** (transient) — matches the BatchWrite reference *cap* (the ramp shape differs: this floors early attempts rather than doubling from a fixed base).
- Replaced all 24 fixed-delay sleeps across the 12 methods (now routed through `d.retryDelay()`).
- **`InternalServerError` → `RetryNeedsBackOff: true`** (retry with exponential backoff, per AWS guidance).
- **`DynamoDB.UseLegacyFlatRetryDelay`** (escape hatch, default `false`): restores the pre-PR timing — the fixed 500ms/100ms schedule **and** the immediate-retry ISE classification — for a consumer whose timeout budget was calibrated to the old behavior and needs a migration window.

## ⚠️ Behavioral changes (activate on version bump — NOT opt-in)
Two changes alter retry **timing** for every consumer the moment they bump `common` (no code change required). Both are correct per AWS DynamoDB retry guidance, but are disclosed here so callers with tight timeout budgets can assess impact:

1. **`InternalServerError` now backs off** instead of retrying immediately. Worst-case ISE recovery wait goes from ~300ms (3 × flat 100ms) to **~3.5s** (500ms + 1s + 2s) at `maxRetries=3` — ~11.7×. The old flat-100ms retry was arguably a bug (hammers a recovering partition).
2. **All `*WithRetry` delays switch from flat to exponential.** Total wait increases ~2–3× but is better-shaped (ramped + capped) and decorrelates concurrent callers vs the old lockstep.

**Mitigation:** set `UseLegacyFlatRetryDelay: true` to keep exact master timing during migration.

**Known limitation (pre-existing, not introduced here):** `*WithRetry` methods sleep via `time.Sleep` and do not observe context cancellation; the worst-case uncancellable block rises from 500ms to 2s. A future PR should add context-aware backoff.

**Not changed:** no exported signature removed/renamed/retyped; no `go.mod` change. With `UseLegacyFlatRetryDelay=false` (default) the *correctness* contract (which errors retry, how many times) is unchanged — only the inter-retry delay schedule.

## Gates
`go build ./...` / `go vet ./wrapper/dynamodb/` / gofmt clean · `go test -race` ok (6 schedule/classification-pinning tests: monotonic/exponential, floor/cap/clamp, backoff≥transient, ISE-now-backs-off, **default-vs-legacy-flat**, **legacy-ISE-restores-immediate**) · whole-module `go test ./... -short` = **55 ok / 0 fail**.

> Found during a deep review of the repo (separate from #77). Independent of #77; both touch `dynamodb.go` in non-overlapping regions. The escape hatch + this disclosure were added after a contrarian backward-compat re-review.
