### PR TITLE
fix(bedrockruntime): bound InvokeModel with a call deadline (hang fix)

### DIFF
--- a/wrapper/bedrockruntime/bedrockruntime.go
+++ b/wrapper/bedrockruntime/bedrockruntime.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"sync"
+	"time"
 
 	awshttp2 "github.com/aldelo/common/wrapper/aws"
 	"github.com/aldelo/common/wrapper/aws/awsregion"
@@ -211,6 +212,26 @@ func (s *BedrockRuntime) UpdateParentSegment(parentSegment *xray.XRayParentSegme
 // to generate text, images, and embeddings. For example code, see Invoke model
 // code examples in the Amazon Bedrock User Guide. This operation requires
 // permission for the bedrock:InvokeModel action.
+// defaultBedrockCallTimeout bounds a single InvokeModel SDK call so a hung
+// Bedrock endpoint (AWS outage / network partition) cannot park the caller's
+// goroutine forever. Bedrock model invocations can legitimately take up to ~2
+// minutes for large prompts, so this is generous compared with fast control-plane
+// calls (cf. wrapper/sns defaultSNSCallTimeout = 30s).
+const defaultBedrockCallTimeout = 120 * time.Second
+
+// bedrockCallCtx builds the deadline-bounded context for an InvokeModel call. It
+// preserves the xray segment lineage when a segment is active (so traces stay
+// linked) and otherwise derives from context.Background() — either way the call
+// is bounded by defaultBedrockCallTimeout. The caller MUST defer the returned
+// cancel.
+func bedrockCallCtx(segCtx context.Context, segCtxSet bool) (context.Context, context.CancelFunc) {
+	parent := context.Background()
+	if segCtxSet && segCtx != nil {
+		parent = segCtx
+	}
+	return context.WithTimeout(parent, defaultBedrockCallTimeout)
+}
+
 func (s *BedrockRuntime) InvokeModel(modelId string, requestBody []byte) (responseBody []byte, err error) {
 	if s == nil {
 		return nil, errors.New("BedrockRuntime receiver is nil")
@@ -259,14 +280,14 @@ func (s *BedrockRuntime) InvokeModel(modelId string, requestBody []byte) (respon
 		ContentType: aws.String("application/json"),
 	}
 
-	// perform action
-	var output *bedrockruntime.InvokeModelOutput
+	// perform action — always under a deadline so a hung Bedrock endpoint cannot
+	// park this goroutine indefinitely (the xray-on path previously passed the
+	// segment ctx, and the xray-off path context.Background(), both deadline-less).
+	callCtx, callCancel := bedrockCallCtx(segCtx, segCtxSet)
+	defer callCancel()
 
-	if segCtxSet {
-		output, err = client.InvokeModel(segCtx, input)
-	} else {
-		output, err = client.InvokeModel(context.Background(), input)
-	}
+	var output *bedrockruntime.InvokeModelOutput
+	output, err = client.InvokeModel(callCtx, input)
 
 	// evaluate result
 	if err != nil {

--- a/wrapper/bedrockruntime/bedrockruntime.go
+++ b/wrapper/bedrockruntime/bedrockruntime.go
@@ -66,6 +66,13 @@ type BedrockRuntime struct {
 	// custom http2 client options
 	HttpOptions *awshttp2.HttpClientSettings
 
+	// CallTimeout, when > 0, overrides the per-InvokeModel call deadline
+	// (defaultBedrockCallTimeout, 120s). Zero (the default) keeps the built-in
+	// bound, so existing callers are unaffected. Set a larger value for a model
+	// or prompt that legitimately runs longer than 120s, or a smaller value to
+	// fit a tighter caller budget.
+	CallTimeout time.Duration
+
 	// store BedrockRuntime client object
 	bedrockruntimeClient *bedrockruntime.Client
 
@@ -219,17 +226,26 @@ func (s *BedrockRuntime) UpdateParentSegment(parentSegment *xray.XRayParentSegme
 // calls (cf. wrapper/sns defaultSNSCallTimeout = 30s).
 const defaultBedrockCallTimeout = 120 * time.Second
 
+// callTimeout resolves the per-InvokeModel call deadline: the caller-configured
+// CallTimeout when set (> 0), otherwise the built-in defaultBedrockCallTimeout.
+func (s *BedrockRuntime) callTimeout() time.Duration {
+	if s != nil && s.CallTimeout > 0 {
+		return s.CallTimeout
+	}
+	return defaultBedrockCallTimeout
+}
+
 // bedrockCallCtx builds the deadline-bounded context for an InvokeModel call. It
 // preserves the xray segment lineage when a segment is active (so traces stay
 // linked) and otherwise derives from context.Background() — either way the call
-// is bounded by defaultBedrockCallTimeout. The caller MUST defer the returned
-// cancel.
-func bedrockCallCtx(segCtx context.Context, segCtxSet bool) (context.Context, context.CancelFunc) {
+// is bounded by the given timeout (see callTimeout). The caller MUST defer the
+// returned cancel.
+func bedrockCallCtx(segCtx context.Context, segCtxSet bool, timeout time.Duration) (context.Context, context.CancelFunc) {
 	parent := context.Background()
 	if segCtxSet && segCtx != nil {
 		parent = segCtx
 	}
-	return context.WithTimeout(parent, defaultBedrockCallTimeout)
+	return context.WithTimeout(parent, timeout)
 }
 
 func (s *BedrockRuntime) InvokeModel(modelId string, requestBody []byte) (responseBody []byte, err error) {
@@ -283,7 +299,7 @@ func (s *BedrockRuntime) InvokeModel(modelId string, requestBody []byte) (respon
 	// perform action — always under a deadline so a hung Bedrock endpoint cannot
 	// park this goroutine indefinitely (the xray-on path previously passed the
 	// segment ctx, and the xray-off path context.Background(), both deadline-less).
-	callCtx, callCancel := bedrockCallCtx(segCtx, segCtxSet)
+	callCtx, callCancel := bedrockCallCtx(segCtx, segCtxSet, s.callTimeout())
 	defer callCancel()
 
 	var output *bedrockruntime.InvokeModelOutput

--- a/wrapper/bedrockruntime/bedrockruntime.go
+++ b/wrapper/bedrockruntime/bedrockruntime.go
@@ -71,6 +71,13 @@ type BedrockRuntime struct {
 	// bound, so existing callers are unaffected. Set a larger value for a model
 	// or prompt that legitimately runs longer than 120s, or a smaller value to
 	// fit a tighter caller budget.
+	//
+	// Set this at construction (like a constructor parameter) and treat it as
+	// immutable thereafter. It is read lock-free on the InvokeModel path; unlike
+	// HttpOptions/the client (which Connect mutates at runtime under mu), this
+	// field has no internal writer, so a getter under mu would not make a direct
+	// consumer write race-free — mutating it concurrently with an in-flight call
+	// is therefore unsupported.
 	CallTimeout time.Duration
 
 	// store BedrockRuntime client object

--- a/wrapper/bedrockruntime/bedrockruntime_timeout_test.go
+++ b/wrapper/bedrockruntime/bedrockruntime_timeout_test.go
@@ -38,7 +38,7 @@ import (
 // was the bug.
 func TestBedrockCallCtx_AlwaysHasDeadline(t *testing.T) {
 	t.Run("no_xray_segment", func(t *testing.T) {
-		ctx, cancel := bedrockCallCtx(nil, false)
+		ctx, cancel := bedrockCallCtx(nil, false, defaultBedrockCallTimeout)
 		defer cancel()
 		dl, ok := ctx.Deadline()
 		if !ok {
@@ -52,7 +52,7 @@ func TestBedrockCallCtx_AlwaysHasDeadline(t *testing.T) {
 	t.Run("xray_segment_set_preserves_lineage_and_deadline", func(t *testing.T) {
 		type ctxKey string
 		parent := context.WithValue(context.Background(), ctxKey("seg"), "x")
-		ctx, cancel := bedrockCallCtx(parent, true)
+		ctx, cancel := bedrockCallCtx(parent, true, defaultBedrockCallTimeout)
 		defer cancel()
 		if _, ok := ctx.Deadline(); !ok {
 			t.Error("no deadline when segCtxSet — xray-on path must also be bounded")
@@ -70,5 +70,38 @@ func TestBedrockCallCtx_AlwaysHasDeadline(t *testing.T) {
 func TestBedrockCallTimeout_ContractPin(t *testing.T) {
 	if defaultBedrockCallTimeout != 120*time.Second {
 		t.Errorf("defaultBedrockCallTimeout = %v, want 120s", defaultBedrockCallTimeout)
+	}
+}
+
+// TestBedrockRuntime_CallTimeout_ZeroUsesDefault pins the opt-in contract: a
+// zero-value CallTimeout (the default for every existing caller) resolves to
+// defaultBedrockCallTimeout, so adding the field changes nothing on a version
+// bump.
+func TestBedrockRuntime_CallTimeout_ZeroUsesDefault(t *testing.T) {
+	s := &BedrockRuntime{}
+	if got := s.callTimeout(); got != defaultBedrockCallTimeout {
+		t.Errorf("callTimeout() with zero CallTimeout = %v, want default %v", got, defaultBedrockCallTimeout)
+	}
+}
+
+// TestBedrockRuntime_CallTimeout_ConfiguredHonored proves a consumer can override
+// the 120s default (e.g. a model/prompt that legitimately needs longer, or a
+// caller with a tighter budget) and that bedrockCallCtx applies the override
+// rather than the default.
+func TestBedrockRuntime_CallTimeout_ConfiguredHonored(t *testing.T) {
+	s := &BedrockRuntime{CallTimeout: 7 * time.Second}
+	if got := s.callTimeout(); got != 7*time.Second {
+		t.Fatalf("callTimeout() = %v, want 7s", got)
+	}
+
+	ctx, cancel := bedrockCallCtx(nil, false, s.callTimeout())
+	defer cancel()
+	dl, ok := ctx.Deadline()
+	if !ok {
+		t.Fatal("configured call ctx has no deadline")
+	}
+	// deadline must reflect the 7s override, NOT the 120s default
+	if until := time.Until(dl); until <= 6*time.Second || until > 7*time.Second+time.Second {
+		t.Errorf("deadline in %v, want ~7s (the configured override, not the 120s default)", until)
 	}
 }

--- a/wrapper/bedrockruntime/bedrockruntime_timeout_test.go
+++ b/wrapper/bedrockruntime/bedrockruntime_timeout_test.go
@@ -1,0 +1,74 @@
+package bedrockruntime
+
+/*
+ * Copyright 2020-2026 Aldelo, LP
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Pins the InvokeModel call-deadline fix. Previously InvokeModel called the SDK
+// with context.Background() on the non-xray path (and the bare xray segment ctx
+// otherwise) — NO timeout. A hung Bedrock endpoint (AWS outage / network
+// partition) parked the caller's goroutine indefinitely; enough concurrent hung
+// calls exhaust the task's goroutines. This mirrors the fix already shipped in
+// wrapper/sns and wrapper/kms (defaultSNSCallTimeout / defaultKMSCallTimeout).
+//
+// The deadline-building is factored into bedrockCallCtx so it can be pinned
+// without a live Bedrock client (the wrapper exposes no client seam to mock the
+// actual InvokeModel call).
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+// TestBedrockCallCtx_AlwaysHasDeadline verifies the call context carries a
+// deadline on BOTH paths (xray segment set or not) — the property whose absence
+// was the bug.
+func TestBedrockCallCtx_AlwaysHasDeadline(t *testing.T) {
+	t.Run("no_xray_segment", func(t *testing.T) {
+		ctx, cancel := bedrockCallCtx(nil, false)
+		defer cancel()
+		dl, ok := ctx.Deadline()
+		if !ok {
+			t.Fatal("no deadline when segCtx unset — a hung Bedrock call would park the goroutine forever")
+		}
+		if until := time.Until(dl); until <= 0 || until > defaultBedrockCallTimeout+time.Second {
+			t.Errorf("deadline in %v, want within (0, %v]", until, defaultBedrockCallTimeout)
+		}
+	})
+
+	t.Run("xray_segment_set_preserves_lineage_and_deadline", func(t *testing.T) {
+		type ctxKey string
+		parent := context.WithValue(context.Background(), ctxKey("seg"), "x")
+		ctx, cancel := bedrockCallCtx(parent, true)
+		defer cancel()
+		if _, ok := ctx.Deadline(); !ok {
+			t.Error("no deadline when segCtxSet — xray-on path must also be bounded")
+		}
+		if ctx.Value(ctxKey("seg")) != "x" {
+			t.Error("segment ctx lineage not preserved (deadline must wrap the segment parent)")
+		}
+	})
+}
+
+// TestBedrockCallTimeout_ContractPin locks the chosen deadline. Bedrock model
+// invokes can legitimately take up to ~2 minutes for large prompts, so the bound
+// is generous (vs SNS's 30s control-plane calls) — changing it is a deliberate
+// decision, not an accidental refactor.
+func TestBedrockCallTimeout_ContractPin(t *testing.T) {
+	if defaultBedrockCallTimeout != 120*time.Second {
+		t.Errorf("defaultBedrockCallTimeout = %v, want 120s", defaultBedrockCallTimeout)
+	}
+}


### PR DESCRIPTION
## Problem
`BedrockRuntime.InvokeModel` called the SDK with `context.Background()` on the non-xray path (and the bare xray segment ctx otherwise) — **no timeout** on either path. A hung Bedrock endpoint (AWS outage / network partition) parks the caller's goroutine **indefinitely**; enough concurrent hung calls exhaust the task's goroutine pool.

`wrapper/sns` and `wrapper/kms` already fixed this exact class (`defaultSNSCallTimeout` / `defaultKMSCallTimeout`); `bedrockruntime` was missed.

## Change
- `defaultBedrockCallTimeout = 120s` — generous, since large-prompt invocations can legitimately take ~2 minutes (vs SNS's 30s control-plane calls).
- `bedrockCallCtx()` wraps either the xray segment ctx (lineage preserved) or `context.Background()` in `WithTimeout(...)`; `InvokeModel` now always calls under that deadline and defers cancel.
- **`BedrockRuntime.CallTimeout` (opt-in override, default `0`)**: `0` keeps the 120s default (byte-identical for existing callers); a positive value overrides it — for a model/prompt that legitimately runs >120s, or a caller with a tighter budget. Mirrors the override-ability of `wrapper/sns`'s `timeOutDuration`. Resolution factored into `callTimeout()`.

## Compatibility
No signature change; `CallTimeout` is additive and defaults to the built-in 120s. The only behavioral change: a previously unbounded call now returns a deadline error after 120s (or the configured `CallTimeout`) instead of hanging forever.

## Gates
`go build ./...` / `go vet` / gofmt clean · `go test -race` ok (deadline-always-present on both paths, segment-lineage preserved, 120s contract pin, **zero-uses-default**, **configured-timeout-honored**) · whole-module `go test ./... -short` = **55 ok / 0 fail**.

> Found during a deep review of the repo (separate from #77/#78). The deadline-building is factored into `bedrockCallCtx` so it's unit-testable without a live Bedrock client. The `CallTimeout` override was added after a contrarian re-review noted the 120s bound was non-configurable.
