### PR TITLE
fix: preserve error chains (%s -> %w) in error-wrapping wrappers

### DIFF
--- a/tcp/tcpclient.go
+++ b/tcp/tcpclient.go
@@ -172,7 +172,7 @@ func (c *TCPClient) Write(data []byte) error {
 	}
 
 	if _, err := _tcpConn.Write(data); err != nil {
-		return fmt.Errorf("Write Data to TCP Server Failed: %s", err.Error())
+		return fmt.Errorf("Write Data to TCP Server Failed: %w", err)
 	} else {
 		return nil
 	}
@@ -212,9 +212,9 @@ func (c *TCPClient) Read() (data []byte, timeout bool, err error) {
 
 	if _, err = _tcpConn.Read(data); err != nil {
 		if strings.Contains(strings.ToLower(err.Error()), "timeout") {
-			return nil, true, fmt.Errorf("Read Data From TCP Server Timeout: %s", err)
+			return nil, true, fmt.Errorf("Read Data From TCP Server Timeout: %w", err)
 		} else {
-			return nil, false, fmt.Errorf("Read Data From TCP Server Failed: %s", err)
+			return nil, false, fmt.Errorf("Read Data From TCP Server Failed: %w", err)
 		}
 	} else {
 		return bytes.Trim(data, "\x00"), false, nil

--- a/tcp/tcpserver.go
+++ b/tcp/tcpserver.go
@@ -355,7 +355,7 @@ func (s *TCPServer) WriteToClient(writeData []byte, clientIP string) error {
 	}
 
 	if _, e := c.Write(writeData); e != nil {
-		return fmt.Errorf("Write To Client IP %s Failed: %s", clientIP, e.Error())
+		return fmt.Errorf("Write To Client IP %s Failed: %w", clientIP, e)
 	}
 	return nil
 }

--- a/wrapper/cloudmap/cloudmap.go
+++ b/wrapper/cloudmap/cloudmap.go
@@ -418,7 +418,7 @@ func (sd *CloudMap) CreateHttpNamespace(name string,
 	output, err = sdClient.CreateHttpNamespaceWithContext(callCtx, input)
 
 	if err != nil {
-		err = fmt.Errorf("CloudMap CreateHttpNamespace Failed: (Create Action) %s", err.Error())
+		err = fmt.Errorf("CloudMap CreateHttpNamespace Failed: (Create Action) %w", err)
 		return "", err
 	}
 

--- a/wrapper/gin/gin.go
+++ b/wrapper/gin/gin.go
@@ -438,7 +438,7 @@ func (g *Gin) RunServer() error {
 		proxies = []string{}
 	}
 	if err := g._ginEngine.SetTrustedProxies(proxies); err != nil {
-		return fmt.Errorf("Run Web Server Failed: SetTrustedProxies errored: %s", err.Error())
+		return fmt.Errorf("Run Web Server Failed: SetTrustedProxies errored: %w", err)
 	}
 
 	// setup html template renderer
@@ -449,7 +449,7 @@ func (g *Gin) RunServer() error {
 	// setup auth middleware
 	if g._ginJwtAuth != nil {
 		if err := g._ginJwtAuth.BuildGinJwtMiddleware(g); err != nil {
-			return fmt.Errorf("Run Web Server Failed: (%s) %s", "Build Auth Middleware Errored", err.Error())
+			return fmt.Errorf("Run Web Server Failed: (%s) %w", "Build Auth Middleware Errored", err)
 		}
 	}
 
@@ -473,7 +473,7 @@ func (g *Gin) RunServer() error {
 	}
 
 	if err != nil {
-		return fmt.Errorf("Web Server '%s' Failed To Start: %s", g.Name, err.Error())
+		return fmt.Errorf("Web Server '%s' Failed To Start: %w", g.Name, err)
 	} else {
 		log.Println("Web Server '" + g.Name + "' Stopped")
 		return nil

--- a/wrapper/gin/ginjwt.go
+++ b/wrapper/gin/ginjwt.go
@@ -372,7 +372,7 @@ func (j *GinJwt) BuildGinJwtMiddleware(g *Gin) error {
 			}
 
 			if err := g.bindInput(c, j.AuthenticateBindingType, loginRequestData); err != nil {
-				return nil, fmt.Errorf("%s: %s", jwt.ErrMissingLoginValues.Error(), err.Error())
+				return nil, fmt.Errorf("%w: %w", jwt.ErrMissingLoginValues, err)
 			}
 
 			if loggedInCredential := j.AuthenticateHandler(loginRequestData); loggedInCredential != nil {
@@ -413,7 +413,7 @@ func (j *GinJwt) BuildGinJwtMiddleware(g *Gin) error {
 	})
 
 	if err != nil {
-		return fmt.Errorf("Setup Gin Jwt Middleware Failed: %s", err.Error())
+		return fmt.Errorf("Setup Gin Jwt Middleware Failed: %w", err)
 	}
 
 	if j.AddClaimsHandler != nil {
@@ -554,7 +554,7 @@ func (j *GinJwt) BuildGinJwtMiddleware(g *Gin) error {
 
 	// now init middleware to set default values if required var not set during setup
 	if errInit := authMiddleware.MiddlewareInit(); errInit != nil {
-		return fmt.Errorf("Init Gin Jwt Middleware Failed: %s", errInit.Error())
+		return fmt.Errorf("Init Gin Jwt Middleware Failed: %w", errInit)
 	}
 
 	// setup login route for LoginHandler

--- a/wrapper/mysql/mysql.go
+++ b/wrapper/mysql/mysql.go
@@ -293,7 +293,7 @@ func (t *MySqlTransaction) Commit() (err error) {
 		// not using xray
 		if e := t.tx.Commit(); e != nil {
 			// on commit error, return error, don't close off transaction
-			err = fmt.Errorf("MySql Commit Transaction Failed, %s", e)
+			err = fmt.Errorf("MySql Commit Transaction Failed, %w", e)
 			return err
 		} else {
 			// transaction commit success
@@ -315,7 +315,7 @@ func (t *MySqlTransaction) Commit() (err error) {
 		subSeg.Capture("Commit-Transaction-Do", func() error {
 			if e := t.tx.Commit(); e != nil {
 				// on commit error, return error, don't close off transaction
-				err = fmt.Errorf("MySql Commit Transaction Failed, %s", e)
+				err = fmt.Errorf("MySql Commit Transaction Failed, %w", e)
 				xray.LogXrayAddFailure("MySQL", subSeg.SafeAddError(err))
 				return err
 			} else {
@@ -390,7 +390,7 @@ func (t *MySqlTransaction) Rollback() (err error) {
 	// perform rollback
 	if t._xrayTxSeg == nil {
 		if e := t.tx.Rollback(); e != nil {
-			err = fmt.Errorf("MySql Rollback Transaction Failed, %s", e)
+			err = fmt.Errorf("MySql Rollback Transaction Failed, %w", e)
 		}
 	} else {
 		subSeg := t._xrayTxSeg.NewSubSegment("Rollback-Transaction")
@@ -398,7 +398,7 @@ func (t *MySqlTransaction) Rollback() (err error) {
 
 		subSeg.Capture("Rollback-Transaction-Do", func() error {
 			if e := t.tx.Rollback(); e != nil {
-				err = fmt.Errorf("MySql Rollback Transaction Failed, %s", e)
+				err = fmt.Errorf("MySql Rollback Transaction Failed, %w", e)
 				xray.LogXrayAddFailure("MySQL", subSeg.SafeAddError(err))
 				return err
 			} else {
@@ -730,7 +730,7 @@ func (svr *MySql) openWithXRay() (err error) {
 		baseDb, e := awsxray.SQLContext("mysql", str)
 
 		if e != nil {
-			err = fmt.Errorf("openWithXRay() Failed During xray.SQLContext(): %s", e.Error())
+			err = fmt.Errorf("openWithXRay() Failed During xray.SQLContext(): %w", e)
 			return err
 		}
 

--- a/wrapper/waf2/waf2.go
+++ b/wrapper/waf2/waf2.go
@@ -254,7 +254,7 @@ func (w *WAF2) Connect() error {
 	}
 
 	if httpCli, httpErr = h2.NewHttp2Client(); httpErr != nil {
-		return fmt.Errorf("Connect to WAF2 Failed: (AWS Session Error) Create Custom Http2 Client Errored = %s", httpErr.Error())
+		return fmt.Errorf("Connect to WAF2 Failed: (AWS Session Error) Create Custom Http2 Client Errored = %w", httpErr)
 	}
 
 	// establish aws session connection and keep session object in struct
@@ -265,7 +265,7 @@ func (w *WAF2) Connect() error {
 		})
 	if err != nil {
 		// aws session error
-		return fmt.Errorf("Connect To WAF2 Failed: (AWS Session Error) %s", err.Error())
+		return fmt.Errorf("Connect To WAF2 Failed: (AWS Session Error) %w", err)
 	}
 
 	// aws session obtained
@@ -383,7 +383,7 @@ LockRetry:
 					continue // retry same lock attempt
 				}
 
-				return fmt.Errorf("Get IP Set Failed: %s", err.Error())
+				return fmt.Errorf("Get IP Set Failed: %w", err)
 			}
 
 			if getOutput == nil || getOutput.IPSet == nil {
@@ -464,7 +464,7 @@ LockRetry:
 				continue // retry same lock attempt
 			}
 
-			return fmt.Errorf("Update IP Set Failed: %s", err.Error())
+			return fmt.Errorf("Update IP Set Failed: %w", err)
 		}
 	}
 
@@ -565,7 +565,7 @@ LockRetry:
 					retryAttempt++
 					continue // retry same lock attempt
 				}
-				return fmt.Errorf("Get Regex Pattern Set Failed: %s", err.Error())
+				return fmt.Errorf("Get Regex Pattern Set Failed: %w", err)
 			}
 
 			if getOutput == nil || getOutput.RegexPatternSet == nil {
@@ -618,7 +618,7 @@ LockRetry:
 				continue // retry same lock attempt
 			}
 
-			return fmt.Errorf("Update Regex Patterns Set Failed: %s", err.Error())
+			return fmt.Errorf("Update Regex Patterns Set Failed: %w", err)
 		}
 	}
 


### PR DESCRIPTION
## Problem
Many wrappers build errors with `fmt.Errorf("...: %s", err.Error())`, which **flattens the error chain**. Callers cannot `errors.Is` / `errors.As` through them, so retry, circuit-breaking, and AWS-error classification logic silently gets the wrong answer (e.g. `wrapper/waf2` flattens AWS SDK errors that callers classify via `errors.As`).

## Change
Convert the **22 genuine error-wrap sites** in the reviewed wrappers from `%s` to `%w`:

| File | Sites | Notes |
|---|---|---|
| `wrapper/waf2` | 6 | AWS SDK errors callers classify via `errors.As` |
| `wrapper/gin` | 3 | incl. two multi-verb format strings (only the trailing error verb converted) |
| `wrapper/gin/ginjwt` | 3 | incl. a double-error site → `%w: %w` so both `jwt.ErrMissingLoginValues` and the bind error stay matchable |
| `tcp/tcpclient` | 3 | `net.OpError` timeout detection |
| `tcp/tcpserver` | 1 | |
| `wrapper/cloudmap` | 1 | the lone non-`%w` site in that file |
| `wrapper/mysql` | 5 | commit/rollback/xray-open |

## Safety
- **Behavior-preserving:** `%w` and `%s` render an error to the **same text**, so log/message output is unchanged — only the chain becomes traversable.
- `go vet` enforces that every `%w` arg is an `error` (it caught one over-broad edit on a `log.Printf` during development, which was reverted).
- Multi-verb format strings had **only their trailing error verb** converted.

## Scope
Limited to the wrappers the deep review surfaced where `errors.Is`/`As` classification matters. A broader repo-wide sweep (~70 more `%s", err.Error()` sites in `tlsconfig`/`helper-struct`/etc.) is intentionally left as a follow-up to keep this PR focused and reviewable.

## Gates
`go build ./...` / `go vet ./...` clean · whole-module `go test ./... -short` = **55 ok / 0 fail**.

> Found during a deep review of the repo (separate from #77/#78/#79).