### PR TITLE
fix(gin): build error-response JSON via encoding/json (CodeQL go/unsafe-quoting #12-#15)

### DIFF
--- a/wrapper/gin/gin_test.go
+++ b/wrapper/gin/gin_test.go
@@ -2,6 +2,7 @@ package gin
 
 import (
 	"bytes"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -20,77 +21,75 @@ func init() {
 }
 
 // --------------------------------------------------------------------------
-// jsonEscapeString tests (unexported pure function)
+// Error-response helpers — byte-exact output + injection-safety
+// (replaced the unexported jsonEscapeString tests after the helpers were
+//  refactored to marshal a typed ginErrorResponse via encoding/json, which
+//  clears the CodeQL go/unsafe-quoting findings on the prior fmt.Sprintf form)
 // --------------------------------------------------------------------------
 
-func TestJsonEscapeString_Plain(t *testing.T) {
-	got := jsonEscapeString("hello world")
-	if got != "hello world" {
-		t.Errorf("plain string: got %q, want %q", got, "hello world")
+// TestGinErrorHelpers_ByteExactOutput pins the exact JSON body bytes so the
+// encoding/json refactor is byte-identical to the former fmt.Sprintf form (no
+// observable-contract change for the 36+ downstream consumers).
+func TestGinErrorHelpers_ByteExactOutput(t *testing.T) {
+	cases := []struct {
+		name   string
+		call   func(c *ginlib.Context)
+		status int
+		want   string
+	}{
+		{"recaptcha", func(c *ginlib.Context) { VerifyGoogleReCAPTCHAv2Failed(c, "captcha invalid") }, 412, `{"errortype":"verify-google-recaptcha-v2","error":"captcha invalid"}`},
+		{"marshal", func(c *ginlib.Context) { MarshalQueryParametersFailed(c, "bad params") }, 412, `{"errortype":"marshal-query-parameters","error":"bad params"}`},
+		{"server", func(c *ginlib.Context) { ActionServerFailed(c, "db timeout") }, 500, `{"errortype":"action-server-failed","error":"db timeout"}`},
+		{"notok", func(c *ginlib.Context) { ActionStatusNotOK(c, "not found info") }, 404, `{"errortype":"action-status-not-ok","error":"not found info"}`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			w := httptest.NewRecorder()
+			c, _ := ginlib.CreateTestContext(w)
+			tc.call(c)
+			if w.Code != tc.status {
+				t.Errorf("status = %d, want %d", w.Code, tc.status)
+			}
+			if got := w.Body.String(); got != tc.want {
+				t.Errorf("body mismatch\n got: %s\nwant: %s", got, tc.want)
+			}
+		})
 	}
 }
 
-func TestJsonEscapeString_Quotes(t *testing.T) {
-	got := jsonEscapeString(`say "hello"`)
-	want := `say \"hello\"`
-	if got != want {
-		t.Errorf("quotes: got %q, want %q", got, want)
+// TestGinErrorHelpers_NoBreakoutUnderInjection is the security pin for the CodeQL
+// go/unsafe-quoting finding: an errInfo carrying JSON metacharacters must NOT
+// break out of the enclosing quotes. The body must stay exactly one JSON object
+// with keys {errortype, error}, the error must round-trip, and no attacker key
+// may appear.
+func TestGinErrorHelpers_NoBreakoutUnderInjection(t *testing.T) {
+	// classic breakout payload + backslash / newline / tab / HTML metacharacters
+	payload := "\",\"injected\":\"pwned\" with \\backslash \n newline \t tab <html>&"
+	helpers := map[string]func(c *ginlib.Context){
+		"recaptcha": func(c *ginlib.Context) { VerifyGoogleReCAPTCHAv2Failed(c, payload) },
+		"marshal":   func(c *ginlib.Context) { MarshalQueryParametersFailed(c, payload) },
+		"server":    func(c *ginlib.Context) { ActionServerFailed(c, payload) },
+		"notok":     func(c *ginlib.Context) { ActionStatusNotOK(c, payload) },
 	}
-}
-
-func TestJsonEscapeString_Backslash(t *testing.T) {
-	got := jsonEscapeString(`path\to\file`)
-	want := `path\\to\\file`
-	if got != want {
-		t.Errorf("backslash: got %q, want %q", got, want)
-	}
-}
-
-func TestJsonEscapeString_Newline(t *testing.T) {
-	got := jsonEscapeString("line1\nline2")
-	want := `line1\nline2`
-	if got != want {
-		t.Errorf("newline: got %q, want %q", got, want)
-	}
-}
-
-func TestJsonEscapeString_Tab(t *testing.T) {
-	got := jsonEscapeString("col1\tcol2")
-	want := `col1\tcol2`
-	if got != want {
-		t.Errorf("tab: got %q, want %q", got, want)
-	}
-}
-
-func TestJsonEscapeString_Empty(t *testing.T) {
-	got := jsonEscapeString("")
-	if got != "" {
-		t.Errorf("empty string: got %q, want empty", got)
-	}
-}
-
-func TestJsonEscapeString_Unicode(t *testing.T) {
-	got := jsonEscapeString("caf\u00e9")
-	// json.Marshal preserves valid UTF-8 without escaping.
-	if got != "caf\u00e9" {
-		t.Errorf("unicode: got %q, want %q", got, "caf\u00e9")
-	}
-}
-
-func TestJsonEscapeString_ControlChars(t *testing.T) {
-	// Control characters like \x00 should be escaped.
-	got := jsonEscapeString("a\x00b")
-	want := `a\u0000b`
-	if got != want {
-		t.Errorf("control char: got %q, want %q", got, want)
-	}
-}
-
-func TestJsonEscapeString_HTMLChars(t *testing.T) {
-	got := jsonEscapeString("<script>alert('xss')</script>")
-	// json.Marshal escapes < > & by default.
-	if got == "<script>alert('xss')</script>" {
-		t.Error("HTML chars should be escaped by json.Marshal")
+	for name, h := range helpers {
+		t.Run(name, func(t *testing.T) {
+			w := httptest.NewRecorder()
+			c, _ := ginlib.CreateTestContext(w)
+			h(c)
+			var got map[string]interface{}
+			if err := json.Unmarshal(w.Body.Bytes(), &got); err != nil {
+				t.Fatalf("body is not one valid JSON object (quote breakout!): %v\nbody=%s", err, w.Body.String())
+			}
+			if len(got) != 2 {
+				t.Errorf("expected exactly 2 keys {errortype,error}, got %d: %v", len(got), got)
+			}
+			if got["error"] != payload {
+				t.Errorf("error value did not round-trip\n got: %q\nwant: %q", got["error"], payload)
+			}
+			if _, ok := got["injected"]; ok {
+				t.Error("INJECTION: attacker key 'injected' broke out into the object")
+			}
+		})
 	}
 }
 

--- a/wrapper/gin/ginhelper.go
+++ b/wrapper/gin/ginhelper.go
@@ -38,41 +38,51 @@ func BindPostDataFailed(c *gin.Context) {
 	}
 }
 
-// jsonEscapeString returns a JSON-safe escaped string value (without surrounding quotes).
-func jsonEscapeString(s string) string {
-	b, _ := json.Marshal(s)
-	// json.Marshal wraps in quotes; strip them
-	if len(b) >= 2 {
-		return string(b[1 : len(b)-1])
-	}
-	return s
+// ginErrorResponse is the JSON body shape shared by the error-response helpers
+// below. Building the body with encoding/json (rather than hand-interpolating
+// the error value into a JSON template with fmt.Sprintf) makes it injection-safe
+// by construction: a double quote (or any metacharacter) in errInfo is escaped
+// by json.Marshal and cannot break out of the enclosing quotes.
+type ginErrorResponse struct {
+	ErrorType string `json:"errortype"`
+	Error     string `json:"error"`
+}
+
+// writeGinErrorJSON marshals a ginErrorResponse and writes it with the given
+// status. c.String preserves the prior content type and produces byte-identical
+// output to the former fmt.Sprintf form (compact JSON, field order == struct
+// declaration order, same json.Marshal escaping). json.Marshal cannot error for
+// a struct of plain string fields, so the error is safely discarded.
+func writeGinErrorJSON(c *gin.Context, status int, errorType string, errInfo string) {
+	b, _ := json.Marshal(ginErrorResponse{ErrorType: errorType, Error: errInfo})
+	c.String(status, string(b))
 }
 
 // VerifyGoogleReCAPTCHAv2Failed will return a 412 response to caller via gin context
 func VerifyGoogleReCAPTCHAv2Failed(c *gin.Context, errInfo string) {
 	if c != nil {
-		c.String(412, fmt.Sprintf(`{"errortype":"verify-google-recaptcha-v2","error":"%s"}`, jsonEscapeString(errInfo)))
+		writeGinErrorJSON(c, 412, "verify-google-recaptcha-v2", errInfo)
 	}
 }
 
 // MarshalQueryParametersFailed will return a 412 response to caller via gin context
 func MarshalQueryParametersFailed(c *gin.Context, errInfo string) {
 	if c != nil {
-		c.String(412, fmt.Sprintf(`{"errortype":"marshal-query-parameters","error":"%s"}`, jsonEscapeString(errInfo)))
+		writeGinErrorJSON(c, 412, "marshal-query-parameters", errInfo)
 	}
 }
 
 // ActionServerFailed will return a 500 response to caller via gin context
 func ActionServerFailed(c *gin.Context, errInfo string) {
 	if c != nil {
-		c.String(500, fmt.Sprintf(`{"errortype":"action-server-failed","error":"%s"}`, jsonEscapeString(errInfo)))
+		writeGinErrorJSON(c, 500, "action-server-failed", errInfo)
 	}
 }
 
 // ActionStatusNotOK will return a 404 response to caller via gin context
 func ActionStatusNotOK(c *gin.Context, errInfo string) {
 	if c != nil {
-		c.String(404, fmt.Sprintf(`{"errortype":"action-status-not-ok","error":"%s"}`, jsonEscapeString(errInfo)))
+		writeGinErrorJSON(c, 404, "action-status-not-ok", errInfo)
 	}
 }
 


### PR DESCRIPTION
## Problem
CodeQL flagged 4 **critical** `go/unsafe-quoting` alerts (#12–#15) in `wrapper/gin/ginhelper.go` (lines 54/61/68/75): the error-response helpers hand-built JSON with `fmt.Sprintf` and a custom `jsonEscapeString` sanitizer — *"if this JSON value contains a double quote, it could break out of the enclosing quotes."*

The custom escaper was actually correct (it wraps `json.Marshal`), so the alerts were **not exploitable today** — but CodeQL cannot model a custom sanitizer, and the pattern is fragile (the `b, _ := json.Marshal(s)` error-discard would fall through to the **raw** string if it ever returned nil).

## Change
- Marshal a typed `ginErrorResponse{ErrorType, Error}` via `encoding/json` (a sink CodeQL models as safe) through one `writeGinErrorJSON` helper; remove `jsonEscapeString`.
- **Byte-identical output:** struct field order == declaration order, same `json.Marshal` escaping (`SetEscapeHTML(true)`), `c.String` preserves the prior content type. Pinned by `TestGinErrorHelpers_ByteExactOutput`.
- **Injection-safety:** `TestGinErrorHelpers_NoBreakoutUnderInjection` feeds a breakout payload (`","injected":"pwned…` + backslash/newline/tab/HTML) and asserts the body stays exactly one JSON object `{errortype,error}`, the error round-trips, and no attacker key appears.
- Replaced the now-removed `jsonEscapeString` unit tests with these end-to-end helper tests.

## Compatibility
No exported signature change; response bytes/status/content-type unchanged for the 36+ consumers. Repo-wide hunt found **no other** `%s`-into-quoted-context sites.

## Gates
`go build` / `go vet` / `gofmt` clean · `go test ./wrapper/gin/` + whole-module `go test ./... -short` = **55 ok / 0 fail** · no new golangci-lint findings · expect CodeQL #12–#15 to auto-resolve on merge.
