### PR TITLE
fix(deps): bump quic-go 0.57.1 -> 0.59.1 (GHSA-vvgj-x9jq-8cj9, Dependabot #38)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -99,7 +99,7 @@ require (
 	github.com/pelletier/go-toml/v2 v2.2.4 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/quic-go/qpack v0.6.0 // indirect
-	github.com/quic-go/quic-go v0.57.1 // indirect
+	github.com/quic-go/quic-go v0.59.1 // indirect
 	github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475 // indirect
 	github.com/sagikazarmark/locafero v0.12.0 // indirect
 	github.com/smartystreets/goconvey v1.8.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -242,8 +242,8 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/quasoft/memstore v0.0.0-20180925164028-84a050167438/go.mod h1:wTPjTepVu7uJBYgZ0SdWHQlIas582j6cn2jgk4DDdlg=
 github.com/quic-go/qpack v0.6.0 h1:g7W+BMYynC1LbYLSqRt8PBg5Tgwxn214ZZR34VIOjz8=
 github.com/quic-go/qpack v0.6.0/go.mod h1:lUpLKChi8njB4ty2bFLX2x4gzDqXwUpaO1DP9qMDZII=
-github.com/quic-go/quic-go v0.57.1 h1:25KAAR9QR8KZrCZRThWMKVAwGoiHIrNbT72ULHTuI10=
-github.com/quic-go/quic-go v0.57.1/go.mod h1:ly4QBAjHA2VhdnxhojRsCUOeJwKYg+taDlos92xb1+s=
+github.com/quic-go/quic-go v0.59.1 h1:0Gmua0HW1Tv7ANR7hUYwRyD0MG5OJfgvYSZasGZzBic=
+github.com/quic-go/quic-go v0.59.1/go.mod h1:upnsH4Ju1YkqpLXC305eW3yDZ4NfnNbmQRCMWS58IKU=
 github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475 h1:N/ElC8H3+5XpJzTSTfLsJV/mx9Q9g7kxmchpfZyxgzM=
 github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/rogpeppe/go-internal v1.10.0 h1:TMyTOH3F/DB16zRVcYyreMH6GnZZrwQVAoYjRBZyWFQ=


### PR DESCRIPTION
## Problem
Dependabot #38 (medium, GHSA-vvgj-x9jq-8cj9): `github.com/quic-go/quic-go` ≤ 0.59.0 is vulnerable to **HTTP/3 QPACK trailer-expansion memory exhaustion**. `go.mod` pinned `v0.57.1` (indirect).

## Exposure
`quic-go` is an **indirect** dependency (pulled by `gin` / `gin-contrib/gzip`); `aldelo/common` imports no HTTP/3 code and never serves HTTP/3. The vulnerable path is only reachable if a downstream consumer opts into gin HTTP/3 serving — **real exposure is low** — but leaving a GHSA-flagged dep unpatched is noise that obscures real issues.

## Change
`go get github.com/quic-go/quic-go@v0.59.1 && go mod tidy` → `0.57.1` → `0.59.1` (go.mod + go.sum only). `gin@v1.11.0` requires only `>=0.54.0`; MVS selects `0.59.1`. No source change; no direct API consumed.

## Gates
`go build ./...` clean · whole-module `go test ./... -short` = **55 ok / 0 fail** · expect Dependabot #38 to auto-close on merge.
